### PR TITLE
pytest-xdist is required for test watch functionality

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ invoke
 
 # Testing
 pytest
+pytest-xdist
 tox
 
 # Docs


### PR DESCRIPTION
test @task allows for a --watch flag, but the resulting pytest arg of
'-f' is not in the base pytest functionality; need the pytest-xdist
plugin for this.