### PR TITLE
Add support for nested prefixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,16 @@ Handling prefixes
         host = env('HOST', 'localhost')  # => 'lolcathost'
         port = env.int('PORT', 5000)  # => 3000
 
+    # nested prefixes are also supported:
+
+    # export MYAPP_DB_HOST=lolcathost
+    # export MYAPP_DB_PORT=10101
+
+    with env.prefixed('MYAPP_'):
+        with env.prefixed('DB_'):
+            db_host = env('HOST', 'lolcathost')
+            db_port = env.int('PORT', 10101)
+
 
 Proxied variables
 -----------------

--- a/environs.py
+++ b/environs.py
@@ -153,9 +153,13 @@ class Env(object):
     @contextlib.contextmanager
     def prefixed(self, prefix):
         """Context manager for parsing envvars with a common prefix."""
-        self._prefix = prefix
+        old_prefix = self._prefix
+        if old_prefix is None:
+            self._prefix = prefix
+        else:
+            self._prefix = "{}{}".format(old_prefix, prefix)
         yield self
-        self._prefix = None
+        self._prefix = old_prefix
 
     def __getattr__(self, name, **kwargs):
         try:

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -346,3 +346,31 @@ class TestPrefix:
             env.int('INT') == 42
             env('NOT_FOUND', 'mydefault') == 'mydefault'
         assert env.dump() == {'APP_STR': 'foo', 'APP_INT': 42, 'APP_NOT_FOUND': 'mydefault'}
+
+class TestNestedPrefix:
+
+    @pytest.fixture(autouse=True)
+    def default_environ(self, set_env):
+        set_env({'APP_STR': 'foo', 'APP_NESTED_INT': '42'})
+
+    def test_nested_prefixed(self, env):
+        with env.prefixed('APP_'):
+            with env.prefixed('NESTED_'):
+                assert env.int('INT') == 42
+                assert env('NOT_FOUND', 'mydefault') == 'mydefault'
+            assert env.str('STR') == 'foo'
+            assert env('NOT_FOUND', 'mydefault') == 'mydefault'
+
+    def test_dump_with_nested_prefixed(self, env):
+        with env.prefixed('APP_'):
+            with env.prefixed('NESTED_'):
+                env.int('INT') == 42
+                env('NOT_FOUND', 'mydefault') == 'mydefault'
+            env.str('STR') == 'foo'
+            env('NOT_FOUND', 'mydefault') == 'mydefault'
+        assert env.dump() == {
+            'APP_STR': 'foo',
+            'APP_NOT_FOUND': 'mydefault',
+            'APP_NESTED_INT': 42,
+            'APP_NESTED_NOT_FOUND': 'mydefault'
+        }


### PR DESCRIPTION
Since I'm using the pattern `APP_DB_<parameter>` a lot I thought it would be nice to have the ability to arbitrarily nesting prefixes instead of being limited to a single level like it happens in the current version.