### PR TITLE
Allow the caller to control whether read_env will recurse.

### DIFF
--- a/environs.py
+++ b/environs.py
@@ -139,16 +139,20 @@ class Env(object):
     __str__ = __repr__
 
     @staticmethod
-    def read_env(path=None):
-        """Read a .env file into os.environ. If .env is not found in the directory from
-        which this method is called, recurse up the directory tree until a .env file is found.
+    def read_env(path=None, recurse=True):
+        """Read a .env file into os.environ.
+
+        If .env is not found in the directory from which this method is called,
+        the default behavior is to recurse up the directory tree until a .env
+        file is found. If you do not wish to recurse up the tree, you may pass
+        False as a second positional argument.
         """
         # By default, start search from the same file this function is called
         if path is None:
             frame = inspect.currentframe().f_back
             caller_dir = os.path.dirname(frame.f_code.co_filename)
             path = os.path.join(os.path.abspath(caller_dir), '.env')
-        return _read_env(path=path)
+        return _read_env(path=path, recurse=recurse)
 
     @contextlib.contextmanager
     def prefixed(self, prefix):


### PR DESCRIPTION
The underlying library already exposes a flag to control this behavior,
so I'm merely adding a passthrough for that flag.

I think this flag should be exposed for the same reason it's exposed in the underlying library: it's very useful. For instance, I don't want a web service process potentially recursing up the file system out of its little "jail" (or at least trying to); it's preferable to me that it just throw an `Exception`. Since that's already something provided by the underlying library, it seems like a good idea to expose it here. I made the default `True` so the change should be backward compatible.