### PR TITLE
Warn instead of raising when .env not found

### DIFF
--- a/environs.py
+++ b/environs.py
@@ -5,6 +5,7 @@ import functools
 import json as pyjson
 import os
 import re
+import warnings
 
 try:
     import urllib.parse as urlparse
@@ -197,8 +198,16 @@ class Env(object):
         if path is None:
             frame = inspect.currentframe().f_back
             caller_dir = os.path.dirname(frame.f_code.co_filename)
-            path = os.path.join(os.path.abspath(caller_dir), ".env")
-        return _read_env(path=path, recurse=recurse)
+            start = os.path.join(os.path.abspath(caller_dir), ".env")
+        else:
+            start = path
+        try:
+            return _read_env(path=start, recurse=recurse)
+        except getattr(__builtins__, "FileNotFoundError", IOError):
+            if path:
+                warnings.warn("{} not found.".format(path), UserWarning)
+            else:
+                warnings.warn(".env file not found.", UserWarning)
 
     @contextlib.contextmanager
     def prefixed(self, prefix):

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -180,6 +180,11 @@ class TestEnvFileReading:
         assert env("STRING") == "foo"
         assert env.list("LIST") == ["wat", "wer", "wen"]
 
+    def test_read_env_not_found(self, env):
+        with pytest.warns(UserWarning) as record:
+            env.read_env("notfound")
+        assert "notfound" in record[0].message.args[0]
+
 
 def always_fail(value):
     raise environs.EnvError("something went wrong")


### PR DESCRIPTION
This is more consistent with expected behavior, and is consistent
with django-environ and envparse

close #10