### PR TITLE
EnvError should inherit from ValueError

### DIFF
--- a/environs.py
+++ b/environs.py
@@ -24,7 +24,7 @@ MARSHMALLOW_VERSION_INFO = tuple(
 )
 
 
-class EnvError(Exception):
+class EnvError(ValueError):
     pass
 
 


### PR DESCRIPTION
Hello,

I feel like EnvError should inherit from ValueError instead of the generic Exception.

For instance, `env.int` of "foo" will raise `EnvError`, while `int("foo")` raises `ValueError`.

It seems to me that both `EnvError` and `ValueError` refer to an error inside the value that cannot be safely typecasted. Since `ValueError` is just a generalization of `EnvError`, `EnvError` should inherit from it.