### PR TITLE
Add try...finally to prefixed method

### DIFF
--- a/environs.py
+++ b/environs.py
@@ -226,12 +226,16 @@ class Env(object):
     @contextlib.contextmanager
     def prefixed(self, prefix):
         """Context manager for parsing envvars with a common prefix."""
-        old_prefix = self._prefix
-        if old_prefix is None:
-            self._prefix = prefix
-        else:
-            self._prefix = "{}{}".format(old_prefix, prefix)
-        yield self
+        try:
+            old_prefix = self._prefix
+            if old_prefix is None:
+                self._prefix = prefix
+            else:
+                self._prefix = "{}{}".format(old_prefix, prefix)
+            yield self
+        finally:
+            # explicitly reset the stored prefix on completion and exceptions
+            self._prefix = None
         self._prefix = old_prefix
 
     def __getattr__(self, name, **kwargs):


### PR DESCRIPTION
This change is a proposed solution to issue #78. 

It adds a test that fails on the code in version 4.1.3 and passes on the code in this change.

It is worth noting that refactoring `Env.prefixed` using the [contextlib](https://docs.python.org/3.7/library/contextlib.html) library might make be a better way to go, but I opted for the simplest fix.