### PR TITLE
Add API for deferred validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 6.1.0 (unreleased)
+
+Features:
+
+- Add deferred validation via the `eager` parameter and `env.seal()` ([#56](https://github.com/sloria/environs/issues/56)).
+  Thanks [robertlagrant](https://github.com/robertlagrant) for the suggestion.
+
 ## 6.0.0 (2019-09-22)
 
 Features:

--- a/examples/deferred_validation_example.py
+++ b/examples/deferred_validation_example.py
@@ -1,0 +1,24 @@
+import os
+from pprint import pprint
+
+from environs import Env, EnvValidationError
+from marshmallow.validate import OneOf, Email, Length, Range
+
+
+os.environ["TTL"] = "-2"
+os.environ["NODE_ENV"] = "invalid"
+os.environ["EMAIL"] = "^_^"
+
+
+env = Env(eager=False)
+TTL = env.int("TTL", validate=Range(min=0, max=100))
+NODE_ENV = env.str(
+    "NODE_ENV", validate=OneOf(["production", "development"], error="NODE_ENV must be one of: {choices}")
+)
+EMAIL = env.str("EMAIL", validate=[Length(min=4), Email()])
+
+# This will raise an error with the combined validation messages
+try:
+    env.seal()
+except EnvValidationError as error:
+    pprint(error.error_messages)


### PR DESCRIPTION
Implements a way to validate all parsed values simultaneously.

```python
from environs import Env

env = Env(eager=False)

DEBUG= env.bool("DEBUG", False)
TTL = env.int("TTL", validate=lambda x: x > 0)

env.seal()  
# environs.EnvValidationError: Environment variables invalid: {'DEBUG': ['Not a valid boolean.'], 'TTL': ['Invalid value.']}
```

`env.seal()` validates the parsed values and prevents further parsing, to ensure that values don't go un-validated.


close #56 


