### PR TITLE
Fix return type of Env.read_env()

### DIFF
--- a/environs.py
+++ b/environs.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse, ParseResult
 from pathlib import Path
 
 import marshmallow as ma
-from dotenv.main import load_dotenv, DotEnv, _walk_to_root
+from dotenv.main import load_dotenv, _walk_to_root
 
 __version__ = "6.1.0"
 __all__ = ["EnvError", "Env"]
@@ -246,7 +246,7 @@ class Env:
         recurse: _BoolType = True,
         verbose: _BoolType = False,
         override: _BoolType = False,
-    ) -> DotEnv:
+    ) -> _BoolType:
         """Read a .env file into os.environ.
 
         If .env is not found in the directory from which this method is called,

--- a/environs.py
+++ b/environs.py
@@ -272,6 +272,7 @@ class Env:
                 check_path = os.path.join(dirname, env_name)
                 if os.path.exists(check_path):
                     return load_dotenv(check_path, verbose=verbose, override=override)
+            return True
         else:
             if path is None:
                 start = os.path.join(start, ".env")

--- a/environs.py
+++ b/environs.py
@@ -246,7 +246,7 @@ class Env:
         recurse: _BoolType = True,
         verbose: _BoolType = False,
         override: _BoolType = False,
-    ) -> _BoolType:
+    ) -> None:
         """Read a .env file into os.environ.
 
         If .env is not found in the directory from which this method is called,
@@ -271,12 +271,12 @@ class Env:
             for dirname in _walk_to_root(start):
                 check_path = os.path.join(dirname, env_name)
                 if os.path.exists(check_path):
-                    return load_dotenv(check_path, verbose=verbose, override=override)
-            return True
+                    load_dotenv(check_path, verbose=verbose, override=override)
+                    return
         else:
             if path is None:
                 start = os.path.join(start, ".env")
-            return load_dotenv(start, verbose=verbose, override=override)
+            load_dotenv(start, verbose=verbose, override=override)
 
     @contextlib.contextmanager
     def prefixed(self, prefix: _StrType) -> typing.Iterator["Env"]:


### PR DESCRIPTION
- Fix typehint of Env.read_env() return_value
- Fix returning None if dotenv file not found recursively. Always return True, just like dotenv.load_dotenv does, regardless of whether the file was found or not.

I set the return value to True for consistency and backwards compatibility. I recommend though that we set the return value to either always None, or return a boolean that expresses whether the dotenv file was found or not.