### PR TITLE
Remove unnecessary __str__ definition

### DIFF
--- a/environs.py
+++ b/environs.py
@@ -240,8 +240,6 @@ class Env:
     def __repr__(self) -> _StrType:
         return "<{} {}>".format(self.__class__.__name__, self._values)
 
-    __str__ = __repr__
-
     @staticmethod
     def read_env(
         path: _StrType = None,


### PR DESCRIPTION
Remove unnecessary `__str__ = __repr__`. If not overridden, `__str__` runs `__repr__` in Python by default.