### PR TITLE
Remove stream kwarg of read_env()

### DIFF
--- a/environs.py
+++ b/environs.py
@@ -246,7 +246,6 @@ class Env:
     def read_env(
         path: _StrType = None,
         recurse: _BoolType = True,
-        stream: _StrType = None,
         verbose: _BoolType = False,
         override: _BoolType = False,
     ) -> DotEnv:
@@ -274,11 +273,11 @@ class Env:
             for dirname in _walk_to_root(start):
                 check_path = os.path.join(dirname, env_name)
                 if os.path.exists(check_path):
-                    return load_dotenv(check_path, stream=stream, verbose=verbose, override=override)
+                    return load_dotenv(check_path, verbose=verbose, override=override)
         else:
             if path is None:
                 start = os.path.join(start, ".env")
-            return load_dotenv(start, stream=stream, verbose=verbose, override=override)
+            return load_dotenv(start, verbose=verbose, override=override)
 
     @contextlib.contextmanager
     def prefixed(self, prefix: _StrType) -> typing.Iterator["Env"]:


### PR DESCRIPTION
Remove the `stream` kwarg of `read_env()`.

Firstly, the kwarg is incorrectly type annotated. It is annotated as `str` and is passed as a kwarg to `dotenv.load_dotenv()`. That kwarg of `dotenv.load_dotenv()`, however, takes an `io.StringIO`, not a string.

Secondly, I believe the `stream` kwarg never does anything here. `dotenv.load_dotenv()` only uses the `stream` kwarg if its first kwarg (`dotenv_path`) is falsy. It seems to me that we always pass a truthy value to that, so `stream` is never used. Therefore I suggest we remove it.

I recommend running mypy with access to site-packages and their typehints in CI (mypy in pre-commit runs in a venv with no site-packages, unless dependencies listed in .pre-commit-config.yaml). It would catch this and a few other issues.