### PR TITLE
Run mypy in CI with dependencies' type annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,6 @@ repos:
   hooks:
   - id: black
     language_version: python3
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.740
-  hooks:
-  - id: mypy
-    # Suppress errors resulting from no access to dependencies' annotations
-    args: ["--ignore-missing-imports", "--no-warn-unused-ignores"]
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.7.9
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,8 @@ repos:
   rev: v0.740
   hooks:
   - id: mypy
+    # Suppress errors resulting from no access to dependencies' annotations
+    args: ["--ignore-missing-imports", "--no-warn-unused-ignores"]
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.7.9
   hooks:

--- a/environs.py
+++ b/environs.py
@@ -62,9 +62,9 @@ def _field2method(
             raise EnvSealedError("Env has already been sealed. New values cannot be parsed.")
         missing = kwargs.pop("missing", None) or default
         if isinstance(field_or_factory, type) and issubclass(field_or_factory, ma.fields.Field):
-            field = typing.cast(typing.Type[ma.fields.Field], field_or_factory)(missing=missing, **kwargs)
+            field = field_or_factory(missing=missing, **kwargs)
         else:
-            field = typing.cast(FieldFactory, field_or_factory)(subcast=subcast, missing=missing, **kwargs)
+            field = field_or_factory(subcast=subcast, missing=missing, **kwargs)
         parsed_key, raw_value, proxied_key = self._get_from_environ(name, ma.missing)
         self._fields[parsed_key] = field
         source_key = proxied_key or parsed_key

--- a/environs.py
+++ b/environs.py
@@ -130,7 +130,7 @@ def _dict2schema(dct, schema_class=ma.Schema):
     return type("", (schema_class,), attrs)
 
 
-def _make_list_field(*, subcast: Subcast, **kwargs) -> ma.fields.List:
+def _make_list_field(*, subcast: typing.Optional[type], **kwargs) -> ma.fields.List:
     inner_field = ma.Schema.TYPE_MAPPING[subcast] if subcast else ma.fields.Field
     return ma.fields.List(inner_field, **kwargs)
 
@@ -183,8 +183,8 @@ class URLField(ma.fields.URL):
 
     # Override deserialize rather than _deserialize because we need
     # to call urlparse *after* validation has occurred
-    def deserialize(self, value: str, attr: str = None, data: typing.Mapping = None) -> ParseResult:
-        ret = super().deserialize(value, attr, data)
+    def deserialize(self, value: str, attr: str = None, data: typing.Mapping = None, **kwargs) -> ParseResult:
+        ret = super().deserialize(value, attr, data, **kwargs)
         return urlparse(ret)
 
 
@@ -195,7 +195,10 @@ class PathField(ma.fields.Str):
 
 
 class LogLevelField(ma.fields.Int):
-    def _format_num(self, value) -> int:
+    # Type ignore, because the return type annotation of the super
+    # class is a private TypeVar incompatible with int. The annotation
+    # in super should probably be Any.
+    def _format_num(self, value) -> int:  # type: ignore
         try:
             return super()._format_num(value)
         except (TypeError, ValueError) as error:

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ select = B,C,E,F,W,T4,B9
 
 [mypy]
 ignore_missing_imports = true
+warn_unreachable = true
+warn_unused_ignores = true
+warn_redundant_casts = true

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ DJANGO_REQUIRES = ["dj-database-url", "dj-email-url"]
 EXTRAS_REQUIRE = {
     "django": DJANGO_REQUIRES,
     "tests": ["pytest"] + DJANGO_REQUIRES,
-    "lint": ["mypy==0.750", "pre-commit~=1.20"],
+    "lint": ["flake8==3.7.9", "flake8-bugbear==19.8.0", "mypy==0.750", "pre-commit~=1.20"],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]
 PYTHON_REQUIRES = ">=3.5"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ DJANGO_REQUIRES = ["dj-database-url", "dj-email-url"]
 EXTRAS_REQUIRE = {
     "django": DJANGO_REQUIRES,
     "tests": ["pytest"] + DJANGO_REQUIRES,
-    "lint": ["flake8==3.7.9", "flake8-bugbear==19.8.0", "pre-commit~=1.20"],
+    "lint": ["mypy==0.750", "pre-commit~=1.20"],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]
 PYTHON_REQUIRES = ">=3.5"

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,10 @@ deps =
 commands = pytest {posargs}
 
 [testenv:lint]
-deps = pre-commit~=1.20
-skip_install = true
-commands = pre-commit run --all-files
+extras = lint
+commands =
+    pre-commit run --all-files
+    mypy .
 
 ; Below tasks are for development only (not run in CI)
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ commands = pytest {posargs}
 extras = lint
 commands =
     pre-commit run --all-files
+    ; Run mypy outside pre-commit because pre-commit runs mypy in a venv
+    ; that doesn't have dependencies or their type annotations installed.
     mypy .
 
 ; Below tasks are for development only (not run in CI)


### PR DESCRIPTION
- Run mypy in an env that has dependencies and their typehints
    - Fix resulting mypy errors
- Add a few strictness flags for mypy
    - Fix resulting mypy errors