### PR TITLE
Remove unused kwargs from __getattr__

### DIFF
--- a/environs.py
+++ b/environs.py
@@ -309,7 +309,7 @@ class Env:
                 "Environment variables invalid: {}".format(error_messages), error_messages
             )
 
-    def __getattr__(self, name: _StrType, **kwargs):
+    def __getattr__(self, name: _StrType):
         try:
             return functools.partial(self.__custom_parsers__[name], self)
         except KeyError as error:


### PR DESCRIPTION
Here's the signature of __getattr__ from official Python docs: [https://docs.python.org/3/reference/datamodel.html#object.__getattr__](https://docs.python.org/3/reference/datamodel.html#object.__getattr__)

We probably shouldn't allow **kwargs here.

Linting fails, but the fix is already in https://github.com/sloria/environs/pull/116 