### PR TITLE
Adding suffixed func to Env class

### DIFF
--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -296,11 +296,11 @@ class Env:
 
     @contextlib.contextmanager
     def suffixed(self, suffix: _StrType) -> typing.Iterator["Env"]:
-        try: 
+        try:
             old_suffix = self._suffix
-            if old_suffix is None: 
+            if old_suffix is None:
                 self._suffix = suffix
-            else: 
+            else:
                 self._suffix = "{}{}".format(suffix, old_suffix)
             yield self
         finally:
@@ -384,9 +384,9 @@ class Env:
         if not omit_prefix:
             if self._prefix and self._suffix:
                 return self._prefix + key + self._suffix
-            if self._prefix: 
-                return self._prefix + key 
-            if self._suffix: 
+            if self._prefix:
+                return self._prefix + key
+            if self._suffix:
                 return key + self._suffix
-            return key 
+            return key
         return key


### PR DESCRIPTION
Hi, everyone.

##  Overview
I would like to suggest adding the suffixed method to Env class.
In some cases, suffix is fixed instead of prefix. For example,

```sh
export HOGE_PATH=aaaa
export FUGA_PATH=aaaa
```

In this case, the below is clearer

```python
env = Env()
env.read_env()
with env.suffixed('_PATH'):
    hoge_path = env.str('HOGE')
    fuga_path = env.str('FUGA')
```

## Details
I did three things

* adding suffixed to environs/__init__.py
* adding test codes corresponded to suffixed
* editing _get_key method

## Alternative Options
* Merging suffixed method into prefixed.

## Remains
- document modification