### PR TITLE
Add support for django-cache-url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.2.0 (unreleased)
+
+- Add `dj_cache_url` for caching Django cache URLs (requires installing with `[django]`)
+  ([#126](https://github.com/sloria/environs/issues/126)).
+  Thanks [epicserve](https://github.com/epicserve) for the suggestion and PR.
+
 ## 7.1.0 (2019-12-07)
 
 - Improve typings and run mypy with dependencies type annotations ([#115](https://github.com/sloria/environs/pull/115)).

--- a/README.md
+++ b/README.md
@@ -326,12 +326,20 @@ the `flask` CLI will automatically read .env and .flaskenv files.
 ## Usage with Django
 
 environs includes a number of helpers for parsing connection URLs. To
-install environs with django support: :
+install environs with django support:
 
     pip install environs[django]
 
-Use `env.dj_db_url` and `env.dj_email_url` to parse the `DATABASE_URL`
+Use `env.dj_db_url`, `env.dj_cache_url` and `env.dj_email_url` to parse the `DATABASE_URL`, `CACHE_URL`
 and `EMAIL_URL` environment variables, respectively.
+
+For more details on URL patterns, see the following projects that environs is using for converting URLs.
+
+* [dj-database-url](https://github.com/jacobian/dj-database-url)
+* [django-cache-url](https://github.com/epicserve/django-cache-url)
+* [dj-email-url](https://github.com/migonzalvar/dj-email-url)
+
+Basic example:
 
 ```python
 # myproject/settings.py
@@ -355,6 +363,9 @@ EMAIL_PORT = email["EMAIL_PORT"]
 EMAIL_HOST_PASSWORD = email["EMAIL_HOST_PASSWORD"]
 EMAIL_HOST_USER = email["EMAIL_HOST_USER"]
 EMAIL_USE_TLS = email["EMAIL_USE_TLS"]
+
+# Parse cache URLS, e.g "redis://localhost:6379/0"
+CACHES = {"default": env.dj_cache_url("CACHE_URL")}
 ```
 
 For local development, use a `.env` file to override the default

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -177,6 +177,17 @@ def _dj_email_url_parser(value: str, **kwargs) -> dict:
     return dj_email_url.parse(value, **kwargs)
 
 
+def _dj_cache_url_parser(value: str, **kwargs) -> dict:
+    try:
+        import django_cache_url
+    except ImportError as error:
+        raise RuntimeError(
+            "The dj_cache_url parser requires the django-cache-url package. "
+            "You can install it with: pip install django-cache-url"
+        ) from error
+    return django_cache_url.parse(value, **kwargs)
+
+
 class URLField(ma.fields.URL):
     def _serialize(self, value: ParseResult, *args, **kwargs) -> str:
         return value.geturl()
@@ -227,6 +238,7 @@ class Env:
     url = _field2method(URLField, "url")
     dj_db_url = _func2method(_dj_db_url_parser, "dj_db_url")
     dj_email_url = _func2method(_dj_email_url_parser, "dj_email_url")
+    dj_cache_url = _func2method(_dj_cache_url_parser, "dj_cache_url")
 
     def __init__(self, *, eager: _BoolType = True):
         self.eager = eager

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import re
 from setuptools import setup
 
-INSTALL_REQUIRES = ["marshmallow>=2.7.0", "python-dotenv"]
+INSTALL_REQUIRES = ["marshmallow>=2.7.0", "python-dotenv==0.10.5"]
 DJANGO_REQUIRES = ["dj-database-url", "dj-email-url", "django-cache-url"]
 EXTRAS_REQUIRE = {
     "django": DJANGO_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import re
 from setuptools import setup
 
-INSTALL_REQUIRES = ["marshmallow>=2.7.0", "python-dotenv==0.10.5"]
+INSTALL_REQUIRES = ["marshmallow>=2.7.0", "python-dotenv"]
 DJANGO_REQUIRES = ["dj-database-url", "dj-email-url", "django-cache-url"]
 EXTRAS_REQUIRE = {
     "django": DJANGO_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup
 
 INSTALL_REQUIRES = ["marshmallow>=2.7.0", "python-dotenv"]
-DJANGO_REQUIRES = ["dj-database-url", "dj-email-url"]
+DJANGO_REQUIRES = ["dj-database-url", "dj-email-url", "django-cache-url"]
 EXTRAS_REQUIRE = {
     "django": DJANGO_REQUIRES,
     "tests": ["pytest"] + DJANGO_REQUIRES,

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 
 import dj_database_url
 import dj_email_url
+import django_cache_url
 import pytest
 from marshmallow import fields, validate
 
@@ -536,6 +537,12 @@ class TestDjango:
         set_env({"EMAIL_URL": email_url})
         res = env.dj_email_url("EMAIL_URL")
         assert res == dj_email_url.parse(email_url)
+
+    def test_dj_cache_url(self, env, set_env):
+        cache_url = "redis://redis:6379/0"
+        set_env({"CACHE_URL": cache_url})
+        res = env.dj_cache_url("CACHE_URL")
+        assert res == django_cache_url.parse(cache_url)
 
 
 class TestDeferredValidation:


### PR DESCRIPTION
Added support for django-cache-url.

**Todo**
[x] Update the readme
[x] Fix one test that is failing locally

@sloria,

I have one test that is failing locally. Let me know if you have any ideas.
```
============================== FAILURES ==============================
___ TestEnvFileReading.test_read_env_not_found_with_verbose_warns ____

self = <test_environs.TestEnvFileReading object at 0x10e694070>
env = <Env {}>

    def test_read_env_not_found_with_verbose_warns(self, env):
        with pytest.warns(UserWarning) as record:
>           env.read_env("notfound", recurse=False, verbose=True)
E           Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) was emitted. The list of emitted warnings is: [].

tests/test_environs.py:233: Failed
------------------------- Captured log call --------------------------
WARNING  dotenv.main:main.py:67 File doesn't exist notfound
==================== 1 failed, 67 passed in 0.17s ====================
```