### PR TITLE
Fix to log_level handler, now accepts lowercase ("info")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.3.0 (unreleased)
+
+- `log_level` accepts lower-cased log level names and rejects invalid
+  names ([#138](https://github.com/sloria/environs/pull/138)).
+  Thanks [gnarvaja](https://github.com/gnarvaja) for the PR.
+
 ## 7.2.0 (2020-02-09)
 
 - Add `dj_cache_url` for caching Django cache URLs (requires installing with `[django]`)

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import marshmallow as ma
 from dotenv.main import load_dotenv, _walk_to_root
 
-__version__ = "7.2.0"
+__version__ = "7.3.0"
 __all__ = ["EnvError", "Env"]
 
 MARSHMALLOW_VERSION_INFO = tuple(int(part) for part in ma.__version__.split(".") if part.isdigit())

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -211,7 +211,7 @@ class LogLevelField(ma.fields.Int):
             return super()._format_num(value)
         except (TypeError, ValueError) as error:
             value = value.upper()
-            if hasattr(logging, value) and isinstance(int, getattr(logging, value)):
+            if hasattr(logging, value) and isinstance(getattr(logging, value), int):
                 return getattr(logging, value)
             else:
                 raise ma.ValidationError("Not a valid log level.") from error

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -210,7 +210,8 @@ class LogLevelField(ma.fields.Int):
         try:
             return super()._format_num(value)
         except (TypeError, ValueError) as error:
-            if hasattr(logging, value):
+            value = value.upper()
+            if hasattr(logging, value) and isinstance(int, getattr(logging, value)):
                 return getattr(logging, value)
             else:
                 raise ma.ValidationError("Not a valid log level.") from error

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -170,9 +170,12 @@ class TestCasting:
         assert env.log_level("LOG_LEVEL_LOWER") == logging.INFO
 
     def test_invalid_log_level(self, set_env, env):
-        set_env({"LOG_LEVEL": "INVALID"})
+        set_env({"LOG_LEVEL": "INVALID", "LOG_LEVEL_BAD": "getLogger"})
         with pytest.raises(environs.EnvError) as excinfo:
             env.log_level("LOG_LEVEL")
+        assert "Not a valid log level" in excinfo.value.args[0]
+        with pytest.raises(environs.EnvError) as excinfo:
+            env.log_level("LOG_LEVEL_BAD")
         assert "Not a valid log level" in excinfo.value.args[0]
 
     @pytest.mark.parametrize("url", ["foo", "42", "foo@bar"])

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -160,9 +160,14 @@ class TestCasting:
         assert isinstance(res, pathlib.Path)
 
     def test_log_level_cast(self, set_env, env):
-        set_env({"LOG_LEVEL": "WARNING", "LOG_LEVEL_INT": str(logging.WARNING)})
+        set_env({
+            "LOG_LEVEL": "WARNING",
+            "LOG_LEVEL_INT": str(logging.WARNING),
+            "LOG_LEVEL_LOWER": "info",
+        })
         assert env.log_level("LOG_LEVEL_INT") == logging.WARNING
         assert env.log_level("LOG_LEVEL") == logging.WARNING
+        assert env.log_level("LOG_LEVEL_LOWER") == logging.INFO
 
     def test_invalid_log_level(self, set_env, env):
         set_env({"LOG_LEVEL": "INVALID"})

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -160,11 +160,7 @@ class TestCasting:
         assert isinstance(res, pathlib.Path)
 
     def test_log_level_cast(self, set_env, env):
-        set_env({
-            "LOG_LEVEL": "WARNING",
-            "LOG_LEVEL_INT": str(logging.WARNING),
-            "LOG_LEVEL_LOWER": "info",
-        })
+        set_env({"LOG_LEVEL": "WARNING", "LOG_LEVEL_INT": str(logging.WARNING), "LOG_LEVEL_LOWER": "info"})
         assert env.log_level("LOG_LEVEL_INT") == logging.WARNING
         assert env.log_level("LOG_LEVEL") == logging.WARNING
         assert env.log_level("LOG_LEVEL_LOWER") == logging.INFO


### PR DESCRIPTION
And validates the attribute from logging module is int.

Previously, sending "info" as value was returning the "info" function.