### PR TITLE
Add argument `raise_error_if_not_found` for read_env

### DIFF
--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -289,7 +289,7 @@ class Env:
             if Path(path).is_dir():
                 raise ValueError("path must be a filename, not a directory.")
             start = Path(path)
-
+        
         is_env_file_found = False
         # TODO: Remove str casts when we drop Python 3.5
         if recurse:
@@ -300,14 +300,12 @@ class Env:
                 check_path = Path(dirname) / env_name
                 if check_path.exists():
                     is_env_file_found = True
-                    load_dotenv(str(check_path), verbose=verbose, override=override,
-                                raise_error_if_not_found=raise_error_if_not_found)
+                    load_dotenv(str(check_path), verbose=verbose, override=override)
                     break
         else:
             if start.exists():
                 is_env_file_found = True
-                load_dotenv(str(start), verbose=verbose, override=override,
-                            raise_error_if_not_found=raise_error_if_not_found)
+                load_dotenv(str(start), verbose=verbose, override=override)
 
         if verbose:
             print('environ: is_env_file_found={}'.format(is_env_file_found))

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -289,7 +289,7 @@ class Env:
             if Path(path).is_dir():
                 raise ValueError("path must be a filename, not a directory.")
             start = Path(path)
-        
+
         is_env_file_found = False
         # TODO: Remove str casts when we drop Python 3.5
         if recurse:
@@ -308,9 +308,9 @@ class Env:
                 load_dotenv(str(start), verbose=verbose, override=override)
 
         if verbose:
-            print('environ: is_env_file_found={}'.format(is_env_file_found))
+            print("environ: is_env_file_found={}".format(is_env_file_found))
         if raise_error_if_not_found and not is_env_file_found:
-            raise IOError('File not found: {}'.format(path or '.env'))
+            raise OSError("File not found: {}".format(path or ".env"))
 
     @contextlib.contextmanager
     def prefixed(self, prefix: _StrType) -> typing.Iterator["Env"]:

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -289,7 +289,7 @@ class Env:
             if Path(path).is_dir():
                 raise ValueError("path must be a filename, not a directory.")
             start = Path(path)
-        
+
         is_env_file_found = False
         # TODO: Remove str casts when we drop Python 3.5
         if recurse:
@@ -300,12 +300,14 @@ class Env:
                 check_path = Path(dirname) / env_name
                 if check_path.exists():
                     is_env_file_found = True
-                    load_dotenv(str(check_path), verbose=verbose, override=override)
+                    load_dotenv(str(check_path), verbose=verbose, override=override,
+                                raise_error_if_not_found=raise_error_if_not_found)
                     break
         else:
             if start.exists():
                 is_env_file_found = True
-                load_dotenv(str(start), verbose=verbose, override=override)
+                load_dotenv(str(start), verbose=verbose, override=override,
+                            raise_error_if_not_found=raise_error_if_not_found)
 
         if verbose:
             print('environ: is_env_file_found={}'.format(is_env_file_found))


### PR DESCRIPTION
- raise IOError when env file not found, this is an essential feature for serious deployment that should not run when the file is missing
- print if env file is found or not when verbose=True