### PR TITLE
 Support for env var substitutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 8.1.0 (unreleased)
+
+Deprecations:
+
+- Variable proxying using the `{{VAR}}` syntax is deprecated
+  and will be removed in environs 9.0.0.
+  Use variable expansion using `${VAR}` instead.
+
+```bash
+# Before
+export MAILGUN_LOGIN=sloria
+export SMTP_LOGIN={{MAILGUN_LOGIN}}
+
+# After
+export MAILGUN_LOGIN=sloria
+export SMTP_LOGIN=${MAILGUN_LOGIN}
+```
+
+```python
+from environs import Env
+
+env = Env(expand_vars=True)
+
+SMTP_LOGIN = env.str("SMTP_LOGIN") # => 'sloria'
+```
+
 ## 8.0.0 (2020-05-27)
 
 Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 8.1.0 (unreleased)
 
+Features:
+
+- Add support for variable expansion, e.g. `MY_VAR=${MY_OTHER_VAR:-mydefault}` ([#168](https://github.com/sloria/environs/pull/168)).
+  Thanks [gnarvaja](https://github.com/gnarvaja) for the PR.
+
 Deprecations:
 
 - Variable proxying using the `{{VAR}}` syntax is deprecated
@@ -23,7 +28,7 @@ from environs import Env
 
 env = Env(expand_vars=True)
 
-SMTP_LOGIN = env.str("SMTP_LOGIN") # => 'sloria'
+SMTP_LOGIN = env.str("SMTP_LOGIN")  # => 'sloria'
 ```
 
 Other changes:

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ year = env.int("YEAR")  # =>2020
 
 ## Proxied variables
 
+**Deprecated: use [Variable expansion](#variable-expansion) instead of proxied variables.**
+
 ```python
 # export MAILGUN_LOGIN=sloria
 # export SMTP_LOGIN={{MAILGUN_LOGIN}}
@@ -351,9 +353,9 @@ and `EMAIL_URL` environment variables, respectively.
 
 For more details on URL patterns, see the following projects that environs is using for converting URLs.
 
-* [dj-database-url](https://github.com/jacobian/dj-database-url)
-* [django-cache-url](https://github.com/epicserve/django-cache-url)
-* [dj-email-url](https://github.com/migonzalvar/dj-email-url)
+- [dj-database-url](https://github.com/jacobian/dj-database-url)
+- [django-cache-url](https://github.com/epicserve/django-cache-url)
+- [dj-email-url](https://github.com/migonzalvar/dj-email-url)
 
 Basic example:
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It allows you to store configuration separate from your code, as per
   - [Reading a specific file](#reading-a-specific-file)
 - [Handling prefixes](#handling-prefixes)
 - [Proxied variables](#proxied-variables)
+- [Envvar substitutions](#substitute-envs)
 - [Validation](#validation)
 - [Deferred validation](#deferred-validation)
 - [Serialization](#serialization)
@@ -166,6 +167,21 @@ with env.prefixed("MYAPP_"):
     with env.prefixed("DB_"):
         db_host = env("HOST", "lolcathost")
         db_port = env.int("PORT", 10101)
+```
+
+## Envvar substitutions variables
+
+```python
+# export CONNECTION_URL=https://${USER:-sloria}:${PASSWORD}@${HOST:-localhost}/
+# export PASSWORD=secret
+# export YEAR=${CURRENT_YEAR:-2020}
+
+from environs import Env
+
+env = Env(substitute_envs=True)
+
+connection_url = env("CONNECTION_URL")  # =>'https://sloria:secret@localhost'
+year = env.int("YEAR")  # =>2020
 ```
 
 ## Proxied variables

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It allows you to store configuration separate from your code, as per
   - [Reading a specific file](#reading-a-specific-file)
 - [Handling prefixes](#handling-prefixes)
 - [Proxied variables](#proxied-variables)
-- [Envvar substitutions](#substitute-envs)
+- [Variable expansion](#variable-expansion)
 - [Validation](#validation)
 - [Deferred validation](#deferred-validation)
 - [Serialization](#serialization)
@@ -169,7 +169,7 @@ with env.prefixed("MYAPP_"):
         db_port = env.int("PORT", 10101)
 ```
 
-## Envvar substitutions variables
+## Variable expansion
 
 ```python
 # export CONNECTION_URL=https://${USER:-sloria}:${PASSWORD}@${HOST:-localhost}/
@@ -178,7 +178,7 @@ with env.prefixed("MYAPP_"):
 
 from environs import Env
 
-env = Env(substitute_envs=True)
+env = Env(expand_vars=True)
 
 connection_url = env("CONNECTION_URL")  # =>'https://sloria:secret@localhost'
 year = env.int("YEAR")  # =>2020

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -20,7 +20,7 @@ __all__ = ["EnvError", "Env"]
 
 MARSHMALLOW_VERSION_INFO = tuple(int(part) for part in ma.__version__.split(".") if part.isdigit())
 _PROXIED_PATTERN = re.compile(r"\s*{{\s*(\S*)\s*}}\s*")
-_ENVVAR_PATTERN = re.compile(r'\$\{([A-Za-z0-9_]+)(:-[^\}:]*)?\}')
+_ENVVAR_PATTERN = re.compile(r"\$\{([A-Za-z0-9_]+)(:-[^\}:]*)?\}")
 
 _T = typing.TypeVar("_T")
 _StrType = str
@@ -251,8 +251,9 @@ class Env:
     dj_email_url = _func2method(_dj_email_url_parser, "dj_email_url")
     dj_cache_url = _func2method(_dj_cache_url_parser, "dj_cache_url")
 
-    def __init__(self, *, eager: _BoolType = True, allow_proxy: _BoolType = True,
-                 substitute_envs: _BoolType = False):
+    def __init__(
+        self, *, eager: _BoolType = True, allow_proxy: _BoolType = True, substitute_envs: _BoolType = False
+    ):
         self.eager = eager
         self._sealed = False  # type: bool
         self.allow_proxy = allow_proxy
@@ -419,7 +420,7 @@ class Env:
             _, env_value, _ = self._get_from_environ(env_key, env_default, proxied=True)
             if env_value is ma.missing:
                 return parsed_key, env_value, env_key
-            ret += value[prev_start:match.start()] + env_value
+            ret += value[prev_start : match.start()] + env_value
             prev_start = match.end()
         ret += value[prev_start:]
 

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -256,13 +256,9 @@ class Env:
     dj_email_url = _func2method(_dj_email_url_parser, "dj_email_url")
     dj_cache_url = _func2method(_dj_cache_url_parser, "dj_cache_url")
 
-    def __init__(
-        self, *, eager: _BoolType = True, allow_proxy: _BoolType = True, expand_vars: _BoolType = False
-    ):
+    def __init__(self, *, eager: _BoolType = True, expand_vars: _BoolType = False):
         self.eager = eager
         self._sealed = False  # type: bool
-        # TODO: Remove allow_proxy in environs 9
-        self.allow_proxy = allow_proxy
         self.expand_vars = expand_vars
         self._fields = {}  # type: typing.Dict[_StrType, ma.fields.Field]
         self._values = {}  # type: typing.Dict[_StrType, typing.Any]
@@ -394,7 +390,8 @@ class Env:
         env_key = self._get_key(key, omit_prefix=proxied)
         value = os.environ.get(env_key, default)
         if hasattr(value, "strip"):
-            match = self.allow_proxy and _PROXIED_PATTERN.match(value)
+            # TODO: Remove proxying in environs 9
+            match = _PROXIED_PATTERN.match(value)
             if match:  # Proxied variable
                 proxied_key = match.groups()[0]
                 warnings.warn(

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -157,7 +157,7 @@ def _preprocess_dict(
         (subcast_key(key.strip()) if subcast_key else key.strip()): (
             subcast(val.strip()) if subcast else val.strip()
         )
-        for key, val in (item.split("=") for item in value.split(",") if value)
+        for key, val in (item.split("=", 1) for item in value.split(",") if value)
     }
 
 

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -425,7 +425,7 @@ class Env:
             if env_default is None:
                 env_default = ma.missing
             else:
-                env_default = env_default[2:]
+                env_default = env_default[2:]  # trim ':-' from default
             _, env_value, _ = self._get_from_environ(env_key, env_default, proxied=True)
             if env_value is ma.missing:
                 return parsed_key, env_value, env_key

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -391,25 +391,24 @@ class Env:
         value = os.environ.get(env_key, default)
         if hasattr(value, "strip"):
             # TODO: Remove proxying in environs 9
-            match = _PROXIED_PATTERN.match(value)
-            if match:  # Proxied variable
-                proxied_key = match.groups()[0]
+            proxy_match = _PROXIED_PATTERN.match(value)
+            if proxy_match:  # Proxied variable
+                proxied_key = proxy_match.groups()[0]
                 warnings.warn(
-                    "Proxied variables are deprecated and will be removed in environs 9. Use variable expansion instead: ${{{proxied_key}}}".format(
-                        proxied_key=proxied_key
-                    ),
+                    "Proxied variables are deprecated and will be removed in environs 9. "
+                    "Use variable expansion instead: ${{{proxied_key}}}".format(proxied_key=proxied_key),
                     RemovedInEnvirons9Warning,
                 )
                 return (key, self._get_from_environ(proxied_key, default, proxied=True)[1], proxied_key)
-            match = self.expand_vars and _EXPANDED_VAR_PATTERN.match(value)
-            if match:  # Full match expand_vars - special case keep default
-                proxied_key = match.groups()[0]
-                subs_default = match.groups()[1]
+            expand_match = self.expand_vars and _EXPANDED_VAR_PATTERN.match(value)
+            if expand_match:  # Full match expand_vars - special case keep default
+                proxied_key = expand_match.groups()[0]
+                subs_default = expand_match.groups()[1]
                 if subs_default is not None:
                     default = subs_default[2:]
                 return (key, self._get_from_environ(proxied_key, default, proxied=True)[1], proxied_key)
-            match = self.expand_vars and _EXPANDED_VAR_PATTERN.search(value)
-            if match:  # Multiple or in text match expand_vars - General case - default lost
+            expand_search = self.expand_vars and _EXPANDED_VAR_PATTERN.search(value)
+            if expand_search:  # Multiple or in text match expand_vars - General case - default lost
                 return self._expand_vars(env_key, value)
             # Remove escaped $
             if self.expand_vars and r"\$" in value:

--- a/tests/.env
+++ b/tests/.env
@@ -4,3 +4,4 @@ STRING=foo
 BOOL=true
 LIST=wat,wer,wen
 PROXIED={{STRING}}
+EXPANDED=${STRING}

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -636,16 +636,18 @@ class TestSubstituteEnvs:
         return environs.Env(substitute_envs=True)
 
     def test_full_substitutions(self, env, set_env):
-        set_env({
-            "MAIN": "${SUBSTI}",
-            "MAIN_INT": "${SUBS_INT}",
-            "MAIN_DEF": "${SUBS_NOT_FOUND:-maindef}",
-            "MAIN_INT_DEF": "${SUBS_NOT_FOUND_I:-454}",
-            "SUBSTI": "substivalue",
-            "SUBS_INT": "48",
-            "USE_DEFAULT": "${FOOBAR}",
-            "UNDEFINED_PROXY": "${MYPROXY}",
-        })
+        set_env(
+            {
+                "MAIN": "${SUBSTI}",
+                "MAIN_INT": "${SUBS_INT}",
+                "MAIN_DEF": "${SUBS_NOT_FOUND:-maindef}",
+                "MAIN_INT_DEF": "${SUBS_NOT_FOUND_I:-454}",
+                "SUBSTI": "substivalue",
+                "SUBS_INT": "48",
+                "USE_DEFAULT": "${FOOBAR}",
+                "UNDEFINED_PROXY": "${MYPROXY}",
+            }
+        )
         assert env.str("MAIN") == "substivalue"
         assert env.int("MAIN_INT") == 48
         assert env.str("MAIN_DEF") == "maindef"
@@ -656,13 +658,15 @@ class TestSubstituteEnvs:
             env.str("UNDEFINED_PROXY")
 
     def test_multiple_substitutions(self, env, set_env):
-        set_env({
-            "PGURL": "postgres://${USER:-sloria}:${PASSWORD:-secret}@localhost",
-            "USER": "gnarvaja",
-            "HELLOCOUNTRY": "Hello ${COUNTRY}",
-            "COUNTRY": "Argentina",
-            "HELLOWORLD": "Hello ${WORLD}",
-        })
+        set_env(
+            {
+                "PGURL": "postgres://${USER:-sloria}:${PASSWORD:-secret}@localhost",
+                "USER": "gnarvaja",
+                "HELLOCOUNTRY": "Hello ${COUNTRY}",
+                "COUNTRY": "Argentina",
+                "HELLOWORLD": "Hello ${WORLD}",
+            }
+        )
         assert env.str("PGURL") == "postgres://gnarvaja:secret@localhost"
         assert env.str("HELLOCOUNTRY") == "Hello Argentina"
 
@@ -670,11 +674,16 @@ class TestSubstituteEnvs:
             env.str("HELLOWORLD")
 
     def test_composite_types(self, env, set_env):
-        set_env({
-            "ALLOWED_USERS": "god,${USER},root",
-            "USER": "gnarvaja",
-            "MYCLASS_KARGS": "foo=bar,wget_params=${WGET_PARAMS}",
-            "WGET_PARAMS": '--header="Referer: https://radiocut.fm/"',
-        })
+        set_env(
+            {
+                "ALLOWED_USERS": "god,${USER},root",
+                "USER": "gnarvaja",
+                "MYCLASS_KARGS": "foo=bar,wget_params=${WGET_PARAMS}",
+                "WGET_PARAMS": '--header="Referer: https://radiocut.fm/"',
+            }
+        )
         assert env.list("ALLOWED_USERS") == ["god", "gnarvaja", "root"]
-        assert env.dict("MYCLASS_KARGS") == {"foo": "bar", "wget_params": '--header="Referer: https://radiocut.fm/"'}
+        assert env.dict("MYCLASS_KARGS") == {
+            "foo": "bar",
+            "wget_params": '--header="Referer: https://radiocut.fm/"',
+        }

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -123,6 +123,10 @@ class TestCasting:
     def test_dict_with_default_from_dict(self, set_env, env):
         assert env.dict("DICT", {"key1": "1"}) == {"key1": "1"}
 
+    def test_dict_with_equal(self, set_env, env):
+        set_env({"DICT": "expr1=1 < 2,expr2=(1+1) = 2"})
+        assert env.dict("DICT") == {"expr1": "1 < 2", "expr2": "(1+1) = 2"}
+
     def test_decimal_cast(self, set_env, env):
         set_env({"DECIMAL": "12.34"})
         assert env.decimal("DECIMAL") == Decimal("12.34")
@@ -664,3 +668,13 @@ class TestSubstituteEnvs:
 
         with pytest.raises(environs.EnvError, match='Environment variable "WORLD" not set'):
             env.str("HELLOWORLD")
+
+    def test_composite_types(self, env, set_env):
+        set_env({
+            "ALLOWED_USERS": "god,${USER},root",
+            "USER": "gnarvaja",
+            "MYCLASS_KARGS": "foo=bar,wget_params=${WGET_PARAMS}",
+            "WGET_PARAMS": '--header="Referer: https://radiocut.fm/"',
+        })
+        assert env.list("ALLOWED_USERS") == ["god", "gnarvaja", "root"]
+        assert env.dict("MYCLASS_KARGS") == {"foo": "bar", "wget_params": '--header="Referer: https://radiocut.fm/"'}


### PR DESCRIPTION
Optional parameter for Env object to allow recursive variable
substitutions.

Example:

```python
# export PG_URL=postgres://${PGUSER:-sloria}:${PGPASS}@${PGHOST:-localhost}
# export PGUSER=gnarvaja
# export PGPASS=secret

env = Env(expand_vars=True)
assert env.str("PG_URL") == "postgres://gnarvaja:secret@localhost"
```
