### PR TITLE
Add delimiter argument to list variable type

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The following are all type-casting methods of `Env`:
 - `env.int`
 - `env.float`
 - `env.decimal`
-- `env.list` (accepts optional `subcast` keyword argument)
+- `env.list` (accepts optional `subcast` and `delimiter` keyword arguments)
 - `env.dict` (accepts optional `subcast_keys` and `subcast_values` keyword arguments)
 - `env.json`
 - `env.datetime`

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -148,10 +148,12 @@ def _make_list_field(*, subcast: typing.Optional[type], **kwargs) -> ma.fields.L
     return ma.fields.List(inner_field, **kwargs)
 
 
-def _preprocess_list(value: typing.Union[str, typing.Iterable], **kwargs) -> typing.Iterable:
+def _preprocess_list(
+    value: typing.Union[str, typing.Iterable], *, delimiter: str = ",", **kwargs
+) -> typing.Iterable:
     if ma.utils.is_iterable_but_not_string(value):
         return value
-    return typing.cast(str, value).split(",") if value != "" else []
+    return typing.cast(str, value).split(delimiter) if value != "" else []
 
 
 def _preprocess_dict(

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -101,6 +101,10 @@ class TestCasting:
         set_env({"LIST": " 1,  2,3"})
         assert env.list("LIST", subcast=int) == [1, 2, 3]
 
+    def test_list_with_spaces_as_delimiter(self, set_env, env):
+        set_env({"LIST": "a b c"})
+        assert env.list("LIST", delimiter=" ") == ["a", "b", "c"]
+
     def test_dict(self, set_env, env):
         set_env({"DICT": "key1=1,key2=2"})
         assert env.dict("DICT") == {"key1": "1", "key2": "2"}


### PR DESCRIPTION
I added the ability to optionally choose the delimiter of list variable types.

Sometimes different delimiters are needed as environment variables don't have a specific convention for that kind of stuff.
It is pretty common to see stuff like `a; b; c` or `a b c`.