### PR TITLE
Loosen ParserMethod typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Features:
   ([#184](https://github.com/sloria/environs/pull/184)).
   Thanks [tomgrin10](https://github.com/tomgrin10?) for the PR.
 
+Bug fixes:
+
+- Loosen `ParserMethod` typing ([#186 (comment)](https://github.com/sloria/environs/issues/186#issuecomment-723163520)).
+  Thanks [hukkinj1](https://github.com/hukkinj1) for the PR.
+
 Other changes:
 
 - When using deferred validation (`eager=False`), parser methods return `None`

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -30,7 +30,7 @@ FieldFactory = typing.Callable[..., ma.fields.Field]
 Subcast = typing.Union[typing.Type, typing.Callable[..., _T]]
 FieldType = typing.Type[ma.fields.Field]
 FieldOrFactory = typing.Union[FieldType, FieldFactory]
-ParserMethod = typing.Callable[..., typing.Optional[_T]]
+ParserMethod = typing.Callable
 
 
 _EXPANDED_VAR_PATTERN = re.compile(r"(?<!\\)\$\{([A-Za-z0-9_]+)(:-[^\}:]*)?\}")

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     pre-commit run --all-files
     ; Run mypy outside pre-commit because pre-commit runs mypy in a venv
     ; that doesn't have dependencies or their type annotations installed.
-    mypy .
+    mypy . examples/
 
 ; Below tasks are for development only (not run in CI)
 


### PR DESCRIPTION
Loosen ParserMethod typing to help with https://github.com/sloria/environs/issues/186#issuecomment-723163520

Otherwise users would have to always do an assert:
```python
ENV_VALUE = env('ENV_VALUE')
assert ENV_VALUE is not None
```
to fix mypy errors.

Also made mypy run against the `examples/` folder to catch typing issues like this early. It is unclear to me why `mypy .` does not discover the `examples/` dir...