### PR TITLE
Apply variable expansion to default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 9.3.1 (unreleased)
+
+Bug fixes:
+
+- Apply variable expansion to default values ([#204](https://github.com/sloria/environs/pull/204)).
+  Thanks [rjcohn](https://github.com/rjcohn) for the PR.
+
 ## 9.3.0 (2020-12-26)
 
 Deprecations:


### PR DESCRIPTION
If a default includes a reference to a variable, expand that reference.
See test_environs.test_default_expands.
Note: type for subs_default is required because of a bug in mypy:
  https://github.com/python/mypy/issues/5423