### PR TITLE
Fix json parser not being descriptive enough (#209).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 9.3.2 (unreleased)
+
+Bug fixes:
+
+- Handle JSON decoding errors when using `env.json` ([#212](https://github.com/sloria/environs/pull/212)).
+  Thanks [bvanelli](https://github.com/bvanelli) for the PR.
+
 ## 9.3.1 (2021-02-07)
 
 Bug fixes:
@@ -28,7 +35,7 @@ Features:
 - Add `delimiter` param to `env.list`
   ([#184](https://github.com/sloria/environs/pull/184)).
 
-Thanks [tomgrin10](https://github.com/tomgrin10?) for the PRs.
+Thanks [tomgrin10](https://github.com/tomgrin10) for the PRs.
 
 Bug fixes:
 

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -81,9 +81,9 @@ def _field2method(
             else:
                 self._errors[parsed_key].append("Environment variable not set.")
                 return None
-        if preprocess:
-            value = preprocess(value, subcast=subcast, **kwargs)
         try:
+            if preprocess:
+                value = preprocess(value, subcast=subcast, **kwargs)
             value = field.deserialize(value)
         except ma.ValidationError as error:
             if self.eager:
@@ -176,7 +176,11 @@ def _preprocess_dict(
 
 
 def _preprocess_json(value: str, **kwargs):
-    return pyjson.loads(value)
+    try:
+        return pyjson.loads(value)
+    except pyjson.JSONDecodeError as error:
+        invalid_json = ma.ValidationError(f"Not a valid json.")
+        raise invalid_json from error
 
 
 _EnumT = typing.TypeVar("_EnumT", bound=Enum)

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -179,7 +179,7 @@ def _preprocess_json(value: str, **kwargs):
     try:
         return pyjson.loads(value)
     except pyjson.JSONDecodeError as error:
-        invalid_json = ma.ValidationError(f"Not a valid json.")
+        invalid_json = ma.ValidationError("Not a valid json.")
         raise invalid_json from error
 
 

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -179,8 +179,7 @@ def _preprocess_json(value: str, **kwargs):
     try:
         return pyjson.loads(value)
     except pyjson.JSONDecodeError as error:
-        invalid_json = ma.ValidationError("Not a valid json.")
-        raise invalid_json from error
+        raise ma.ValidationError("Not valid JSON.") from error
 
 
 _EnumT = typing.TypeVar("_EnumT", bound=Enum)

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -167,7 +167,7 @@ class TestCasting:
         set_env({"JSON": "foo"})
         with pytest.raises(environs.EnvError) as exc:
             env.json("JSON")
-        assert 'Not a valid json.' in exc.value.args[0]
+        assert "Not a valid json." in exc.value.args[0]
 
     def test_datetime_cast(self, set_env, env):
         dtime = dt.datetime.utcnow()

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -167,7 +167,7 @@ class TestCasting:
         set_env({"JSON": "foo"})
         with pytest.raises(environs.EnvError) as exc:
             env.json("JSON")
-        assert "Not a valid json." in exc.value.args[0]
+        assert "Not valid JSON." in exc.value.args[0]
 
     def test_datetime_cast(self, set_env, env):
         dtime = dt.datetime.utcnow()

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -163,6 +163,12 @@ class TestCasting:
         set_env({"JSON": '{"foo": "bar", "baz": [1, 2, 3]}'})
         assert env.json("JSON") == {"foo": "bar", "baz": [1, 2, 3]}
 
+    def test_invalid_json_raises_error(self, set_env, env):
+        set_env({"JSON": "foo"})
+        with pytest.raises(environs.EnvError) as exc:
+            env.json("JSON")
+        assert 'Not a valid json.' in exc.value.args[0]
+
     def test_datetime_cast(self, set_env, env):
         dtime = dt.datetime.utcnow()
         set_env({"DTIME": dtime.isoformat()})


### PR DESCRIPTION
Old error message:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

New error message:

```
environs.EnvValidationError: Environment variable "JSON" invalid: Not a valid json.
```