### PR TITLE
Test against Python 3.10; reduce jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 9.4.0 (unreleased)
+
+Other changes:
+
+- Test against Python 3.10.
+
 ## 9.3.5 (2021-11-14)
 
 Bug fixes:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
   - template: job--python-tox.yml@sloria
     parameters:
       toxenvs:
-        - py10-marshmallow3
+        - py310-marshmallow3
       os: windows
   - template: job--python-tox.yml@sloria
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,18 +25,15 @@ jobs:
   - template: job--python-tox.yml@sloria
     parameters:
       toxenvs:
-        - py38-marshmallow3
+        - py10-marshmallow3
       os: windows
   - template: job--python-tox.yml@sloria
     parameters:
       toxenvs:
         - lint
         - py36-marshmallowlowest
-        - py36-marshmallow3
-        - py37-marshmallow3
-        - py38-marshmallow3
-        - py39-marshmallow3
-        - py39-marshmallowdev
+        - py10-marshmallow3
+        - py10-marshmallowdev
       os: linux
   - template: job--pypi-release.yml@sloria
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,8 +32,8 @@ jobs:
       toxenvs:
         - lint
         - py36-marshmallowlowest
-        - py10-marshmallow3
-        - py10-marshmallowdev
+        - py310-marshmallow3
+        - py310-marshmallowdev
       os: linux
   - template: job--pypi-release.yml@sloria
     parameters:

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Typing :: Typed",
     ],
     project_urls={


### PR DESCRIPTION
As in marshmallow (https://github.com/marshmallow-code/marshmallow/pull/1888), only test lowest and highest python versions.