### PR TITLE
Accept any type as default json parser value (number 2)

### DIFF
--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -209,7 +209,10 @@ def _preprocess_json(value: typing.Union[str, typing.Mapping, typing.List], **kw
     try:
         if isinstance(value, str):
             return pyjson.loads(value)
-        return value
+        elif isinstance(value, dict) or isinstance(value, list) or value is None:
+            return value
+        else:
+            raise ma.ValidationError("Not valid JSON.")
     except pyjson.JSONDecodeError as error:
         raise ma.ValidationError("Not valid JSON.") from error
 

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -173,8 +173,10 @@ def _preprocess_dict(
     }
 
 
-def _preprocess_json(value: str, **kwargs):
-    return pyjson.loads(value)
+def _preprocess_json(value: typing.Union[str, typing.Mapping, typing.List], **kwargs):
+    if isinstance(value, str):
+        return pyjson.loads(value)
+    return value
 
 
 _EnumT = typing.TypeVar("_EnumT", bound=Enum)

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -173,6 +173,13 @@ class TestCasting:
             env.json("JSON")
         assert "Not valid JSON." in exc.value.args[0]
 
+    def test_json_default(self, set_env, env):
+        assert env.json("JSON", {"foo": "bar"}) == {"foo": "bar"}
+        assert env.json("JSON", ["foo", "bar"]) == ["foo", "bar"]
+        with pytest.raises(environs.EnvError) as exc:
+            env.json("JSON", int)  # a builtin is not a valid json
+        assert "Not valid JSON." in exc.value.args[0]
+
     def test_datetime_cast(self, set_env, env):
         dtime = dt.datetime.utcnow()
         set_env({"DTIME": dtime.isoformat()})


### PR DESCRIPTION
This is a copy of https://github.com/sloria/environs/pull/198

I finally wrote the tests. Here is also some consideration, lists and dicts should be directly considered as json (as well as null itself), but strings should always be parsed as they are not valid json.

https://stackoverflow.com/questions/7487869/is-this-simple-string-considered-valid-json

Python agrees with this definition:

```python
import json
json.loads("{}")       # works
json.loads("[]")       # works
json.loads("null")     # works
json.loads("string")   # raises error
```