### PR TITLE
Add support for custom functions on subcast.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 9.5.0 (unreleased)
+
+Features:
+
+- Allow callables or custom marshmallow fields to be passed to `subcast`, `subcast_keys`, and `subcast_values`. ([#241](https://github.com/sloria/environs/pull/241)).
+  Thanks [bvanelli](https://github.com/bvanelli) for the PR.
+
 ## 9.4.0 (2022-01-04)
 
 Bug fixes:
@@ -28,7 +35,7 @@ Bug fixes:
 
 Bug fixes:
 
-- Fix compatibility with marshmallow>=3.13.0 
+- Fix compatibility with marshmallow>=3.13.0
   so that no DeprecationWarnings are raised ([#224](https://github.com/sloria/environs/issues/224)).
 
 ## 9.3.2 (2021-03-28)


### PR DESCRIPTION
Allows users to define custom functions or extend mashmallow fields.Field class to write custom subcasts for lists, dict keys and
dict values. Before, the user was limited to the casts defined on `ma.Schema.TYPE_MAPPING`

Gives an alternative to solve https://github.com/sloria/environs/issues/216, as shown on the tests.

I also made it available with callables not derived from `mashmallow.fields.Field` because the handy lambda functions could be used too.

