### PR TITLE
fix CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - id: pyupgrade
     args: [--py37-plus]
 - repo: https://github.com/python/black
-  rev: 22.1.0
+  rev: 22.10.0
   hooks:
   - id: black
     language_version: python3


### PR DESCRIPTION
Current `master` branch build fails, see https://dev.azure.com/sloria/sloria/_build/results?buildId=12400&view=logs&j=ea246cef-d1aa-57f5-7a3e-96f81afd1e8b&t=dbea0cb8-2fce-5953-3cb5-dc5f7d114bd9&l=43

```
Traceback (most recent call last):
  File "/home/vsts/.cache/pre-commit/repo5cfip9ka/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/vsts/.cache/pre-commit/repo5cfip9ka/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 1423, in patched_main
    patch_click()
  File "/home/vsts/.cache/pre-commit/repo5cfip9ka/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 1409, in patch_click
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (/home/vsts/.cache/pre-commit/repo5cfip9ka/py_env-python3/lib/python3.10/site-packages/click/__init__.py)
```

This just requires a black update, see https://github.com/psf/black/issues/2964