### PR TITLE
__repr__ and __str__ don't display envvars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 10.3.0 (unreleased)
+
+Features:
+
+- `Env.__repr__` and `Env.__str__` no longer display environment variables, to prevent accidental exfiltration of sensitive data ([#292](https://github.com/sloria/environs/issues/292)).
+  Thanks [mro-rhansen2](https://github.com/mro-rhansen2) for the suggestion.
+
 ## 10.2.0 (2024-01-09)
 
 Features:

--- a/environs/__init__.py
+++ b/environs/__init__.py
@@ -387,7 +387,7 @@ class Env:
         self.__custom_parsers__: typing.Dict[_StrType, ParserMethod] = {}
 
     def __repr__(self) -> _StrType:
-        return f"<{self.__class__.__name__} {self._values}>"
+        return f"<{self.__class__.__name__}(eager={self.eager}, expand_vars={self.expand_vars})>"
 
     @staticmethod
     def read_env(

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -487,15 +487,17 @@ class TestDumping:
 
 
 def test_repr(set_env, env):
+    env = environs.Env(eager=True, expand_vars=True)
     set_env({"FOO": "foo", "BAR": "42"})
     env.str("FOO")
-    assert repr(env) == "<Env {}>".format({"FOO": "foo"})
+    assert repr(env) == "<Env(eager=True, expand_vars=True)>"
 
 
 def test_str(set_env, env):
+    env = environs.Env(eager=True, expand_vars=True)
     set_env({"FOO": "foo", "BAR": "42"})
     env.str("FOO")
-    assert repr(env) == "<Env {}>".format({"FOO": "foo"})
+    assert str(env) == "<Env(eager=True, expand_vars=True)>"
 
 
 def test_env_isolation(set_env):


### PR DESCRIPTION
close #292 