### PR TITLE
Add typing to ParserMethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ env.str("EMAIL", validate=[Length(min=4), Email()])
 
 By default, a validation error is raised immediately upon calling a parser method for an invalid environment variable.
 To defer validation and raise an exception with the combined error messages for all invalid variables, pass `eager=False` to `Env`.
+Unvalidated variables may have any type, usually `str | None`.
 Call `env.seal()` after all variables have been parsed.
 
 ```python

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -54,23 +54,21 @@ _dict = typing.Dict[str, typing.Any]
 class _ParserMethod(typing.Generic[_T]):
     """Duck typing, do not use"""
 
-    def __call__(  # type: ignore[empty-body]
+    @typing.overload  # type: ignore[no-overload-impl]
+    def __call__(
         self,
         name: str,
-        default: typing.Any = ma.missing,
+        default: None,
         subcast: typing.Optional[Subcast] = None,
-        *,
-        # Subset of relevant marshmallow.Field kwargs
-        load_default: typing.Any = ma.missing,
-        validate: typing.Union[
-            typing.Callable[[typing.Any], typing.Any],
-            typing.Iterable[typing.Callable[[typing.Any], typing.Any]],
-            None,
-        ] = None,
-        required: bool = False,
-        allow_none: typing.Optional[bool] = None,
-        error_messages: typing.Optional[typing.Dict[str, str]] = None,
-        metadata: typing.Optional[typing.Mapping[str, typing.Any]] = None,
+        **kwargs,
+    ) -> typing.Optional[_T]: ...
+
+    @typing.overload
+    def __call__(
+        self,
+        name: str,
+        default: typing.Union[ma.utils._Missing, _T] = ma.missing,
+        subcast: typing.Optional[Subcast] = None,
         **kwargs,
     ) -> _T: ...
 

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -51,7 +51,7 @@ _list = typing.List[typing.Any]
 _dict = typing.Dict[str, typing.Any]
 
 
-class ParserMethod(typing.Generic[_T]):
+class _ParserMethod(typing.Generic[_T]):
     """Duck typing, do not use"""
 
     def __call__(  # type: ignore[empty-body]
@@ -108,7 +108,7 @@ def _field2method(
     *,
     preprocess: typing.Optional[typing.Callable] = None,
     preprocess_kwarg_names: typing.Sequence[str] = tuple(),
-) -> ParserMethod:
+) -> _ParserMethod:
     def method(
         self: "Env",
         name: str,
@@ -183,7 +183,7 @@ def _field2method(
     return method  # type: ignore[return-value]
 
 
-def _func2method(func: typing.Callable, method_name: str) -> ParserMethod:
+def _func2method(func: typing.Callable, method_name: str) -> _ParserMethod:
     def method(
         self: "Env",
         name: str,
@@ -402,20 +402,20 @@ class LogLevelField(ma.fields.Int):
 class Env:
     """An environment variable reader."""
 
-    __call__: ParserMethod[str] = _field2method(ma.fields.Field, "__call__")
+    __call__: _ParserMethod[str] = _field2method(ma.fields.Field, "__call__")
 
-    int: ParserMethod[_int] = _field2method(ma.fields.Int, "int")
-    bool: ParserMethod[_bool] = _field2method(ma.fields.Bool, "bool")
-    str: ParserMethod[_str] = _field2method(ma.fields.Str, "str")
-    float: ParserMethod[_float] = _field2method(ma.fields.Float, "float")
-    decimal: ParserMethod[Decimal] = _field2method(ma.fields.Decimal, "decimal")
-    list: ParserMethod[_list] = _field2method(
+    int: _ParserMethod[_int] = _field2method(ma.fields.Int, "int")
+    bool: _ParserMethod[_bool] = _field2method(ma.fields.Bool, "bool")
+    str: _ParserMethod[_str] = _field2method(ma.fields.Str, "str")
+    float: _ParserMethod[_float] = _field2method(ma.fields.Float, "float")
+    decimal: _ParserMethod[Decimal] = _field2method(ma.fields.Decimal, "decimal")
+    list: _ParserMethod[_list] = _field2method(
         _make_list_field,
         "list",
         preprocess=_preprocess_list,
         preprocess_kwarg_names=("subcast", "delimiter"),
     )
-    dict: ParserMethod[_dict] = _field2method(
+    dict: _ParserMethod[_dict] = _field2method(
         ma.fields.Dict,
         "dict",
         preprocess=_preprocess_dict,
@@ -427,27 +427,27 @@ class Env:
             "delimiter",
         ),
     )
-    json: ParserMethod[_dict] = _field2method(
+    json: _ParserMethod[_dict] = _field2method(
         ma.fields.Field, "json", preprocess=_preprocess_json
     )
-    datetime: ParserMethod[_datetime] = _field2method(ma.fields.DateTime, "datetime")
-    date: ParserMethod[_date] = _field2method(ma.fields.Date, "date")
-    time: ParserMethod[_time] = _field2method(ma.fields.Time, "time")
-    path: ParserMethod[Path] = _field2method(PathField, "path")
-    log_level: ParserMethod[_int] = _field2method(LogLevelField, "log_level")
-    timedelta: ParserMethod[_timedelta] = _field2method(
+    datetime: _ParserMethod[_datetime] = _field2method(ma.fields.DateTime, "datetime")
+    date: _ParserMethod[_date] = _field2method(ma.fields.Date, "date")
+    time: _ParserMethod[_time] = _field2method(ma.fields.Time, "time")
+    path: _ParserMethod[Path] = _field2method(PathField, "path")
+    log_level: _ParserMethod[_int] = _field2method(LogLevelField, "log_level")
+    timedelta: _ParserMethod[_timedelta] = _field2method(
         ma.fields.TimeDelta, "timedelta"
     )
-    uuid: ParserMethod[UUID] = _field2method(ma.fields.UUID, "uuid")
-    url: ParserMethod[_str] = _field2method(URLField, "url")
-    enum: ParserMethod[Enum] = _func2method(_enum_parser, "enum")
-    dj_db_url: ParserMethod[typing.Dict[_str, _str]] = _func2method(
+    uuid: _ParserMethod[UUID] = _field2method(ma.fields.UUID, "uuid")
+    url: _ParserMethod[_str] = _field2method(URLField, "url")
+    enum: _ParserMethod[Enum] = _func2method(_enum_parser, "enum")
+    dj_db_url: _ParserMethod[typing.Dict[_str, _str]] = _func2method(
         _dj_db_url_parser, "dj_db_url"
     )
-    dj_email_url: ParserMethod[typing.Dict[_str, _str]] = _func2method(
+    dj_email_url: _ParserMethod[typing.Dict[_str, _str]] = _func2method(
         _dj_email_url_parser, "dj_email_url"
     )
-    dj_cache_url: ParserMethod[typing.Dict[_str, _str]] = _func2method(
+    dj_cache_url: _ParserMethod[typing.Dict[_str, _str]] = _func2method(
         _dj_cache_url_parser, "dj_cache_url"
     )
 
@@ -459,7 +459,7 @@ class Env:
         self._values: typing.Dict[_StrType, typing.Any] = {}
         self._errors: ErrorMapping = collections.defaultdict(list)
         self._prefix: typing.Optional[_StrType] = None
-        self.__custom_parsers__: typing.Dict[_StrType, ParserMethod] = {}
+        self.__custom_parsers__: typing.Dict[_StrType, _ParserMethod] = {}
 
     def __repr__(self) -> _StrType:
         return f"<{self.__class__.__name__}(eager={self.eager}, expand_vars={self.expand_vars})>"  # noqa: E501

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -106,7 +106,7 @@ def _field2method(
     *,
     preprocess: typing.Optional[typing.Callable] = None,
     preprocess_kwarg_names: typing.Sequence[str] = tuple(),
-) -> _ParserMethod:
+):
     def method(
         self: "Env",
         name: str,
@@ -178,10 +178,10 @@ def _field2method(
         return value
 
     method.__name__ = method_name
-    return method  # type: ignore[return-value]
+    return method
 
 
-def _func2method(func: typing.Callable, method_name: str) -> _ParserMethod:
+def _func2method(func: typing.Callable, method_name: str):
     def method(
         self: "Env",
         name: str,
@@ -226,7 +226,7 @@ def _func2method(func: typing.Callable, method_name: str) -> _ParserMethod:
         return value
 
     method.__name__ = method_name
-    return method  # type: ignore[return-value]
+    return method
 
 
 def _make_subcast_field(


### PR DESCRIPTION
Assumes `eager=False`: parsers are shown to return their base type and neither `Any` nor `None`.

I think this should be fine as users should call `env.seal()` and either terminate or at least not use invalid values in case of errors.