### PR TITLE
Use an appropriate minimum version for marshmallow on python 3.12+

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@ envlist=
 [testenv]
 extras = tests
 deps =
-    marshmallowlowest: marshmallow==3.13.0
+    marshmallowlowest: marshmallow==3.13.0;python_version<"3.12"
+    marshmallowlowest: marshmallow==3.20.2;python_version>="3.12"
     marshmallow3: marshmallow>=3.13.0,<4.0.0
     marshmallowdev: https://github.com/marshmallow-code/marshmallow/archive/dev.tar.gz
 commands = pytest {posargs}


### PR DESCRIPTION
Fix `py312-marshmallowlowest` : ma 3.13 is not compatible with Python 3.12 as it tries to use the removed module `distutils`. 

ma 3.20.2 is the first version with official support for py312.