### PR TITLE
amended type definition for ParserMethod

### DIFF
--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -27,7 +27,7 @@ FieldFactory = typing.Callable[..., ma.fields.Field]
 Subcast = typing.Union[typing.Type, typing.Callable[..., _T], ma.fields.Field]
 FieldType = typing.Type[ma.fields.Field]
 FieldOrFactory = typing.Union[FieldType, FieldFactory]
-ParserMethod = typing.Callable
+ParserMethod = typing.Callable[..., object]
 
 
 _EXPANDED_VAR_PATTERN = re.compile(r"(?<!\\)\$\{([A-Za-z0-9_]+)(:-[^\}:]*)?\}")


### PR DESCRIPTION
### PR: Update `ParserMethod` Type Alias for More Flexibility

#### Summary:
This PR updates the `ParserMethod` type alias to `Callable[..., object]`, which allows it to handle functions with any number of arguments and any return type. This change makes the type more flexible and compatible with a wider range of functions in the codebase.

#### What Changed:
- **Old Type Alias**: `ParserMethod = typing.Callable` (incomplete).
- **New Type Alias**: `ParserMethod = Callable[..., object]`
  - The new type definition allows:
    - Any number of arguments (`...`).
    - Arguments of any type.
    - Return type of any type (`object`).

#### Why This Change:
The old type alias was too general and not fully defined. By switching to `Callable[..., object]`, we ensure better flexibility for callables, supporting a wider variety of function signatures with different argument types and return types.

#### Impact:
- This change doesn’t affect the existing functionality, but it makes type checking more precise for functions with dynamic arguments or return types.
- It ensures we can use `ParserMethod` for more generic functions without any issues.
