### PR TITLE
Fix read_env recursive bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 11.2.1 (unreleased)
+
+Bug fixes:
+
+- Fix `Env.read_env(recurse=True)` so that it returns as soon as a `.env`
+  file is found ([#370](https://github.com/sloria/environs/pull/370)).
+  Thanks [senese](https://github.com/senese) for the PR.
+
 ## 11.2.0 (2024-11-14)
 
 Features:

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -488,6 +488,7 @@ class Env:
                         check_path, verbose=verbose, override=override
                     )
                     env_path = str(check_path)
+                    break
         else:
             is_env_loaded = load_dotenv(str(start), verbose=verbose, override=override)
             env_path = str(start)

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -454,7 +454,7 @@ class Env:
         verbose: _BoolType = False,
         override: _BoolType = False,
         return_path: _BoolType = False,
-    ) -> typing.Union[_BoolType, _StrType]:
+    ) -> typing.Union[_BoolType, typing.Optional[_StrType]]:
         """Read a .env file into os.environ.
 
         If .env is not found in the directory from which this method is called,
@@ -462,8 +462,7 @@ class Env:
         file is found. If you do not wish to recurse up the tree, you may pass
         False as a second positional argument.
         """
-
-        env_path = ""
+        env_path = None
         is_env_loaded = False
         if path is None:
             # By default, start search from the same directory this function is called

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -490,6 +490,7 @@ class Env:
                     )
                     env_path = str(check_path)
                     break
+
         else:
             is_env_loaded = load_dotenv(str(start), verbose=verbose, override=override)
             env_path = str(start)

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -463,6 +463,7 @@ class Env:
         False as a second positional argument.
         """
 
+        env_path = ""
         is_env_loaded = False
         if path is None:
             # By default, start search from the same directory this function is called

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -15,7 +15,6 @@ import pytest
 from marshmallow import fields, validate
 
 import environs
-import tempfile
 
 HERE = pathlib.Path(__file__).parent
 

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -407,6 +407,17 @@ class TestEnvFileReading:
         env_path = str(HERE / ".env")
         assert path == env_path
 
+    def test_read_env_return_path_with_dotenv_on_working_dir(self, env):
+        working_dir = pathlib.Path(os.getcwd())
+        dotenv_path = working_dir / ".env"
+        open(dotenv_path, "x")  # create .env on working dir
+
+        path = env.read_env(return_path=True)
+        env_path = str(HERE / ".env")
+        assert path == env_path
+
+        os.remove(dotenv_path)
+
 
 def always_fail(value):
     raise environs.EnvError("something went wrong")

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -426,17 +426,14 @@ class TestEnvFileReading:
         # Move .env file to temp location
         env_path = HERE / ".env"
         temp_env = tmp_path / ".env"
-        env_path.rename(temp_env)
-
         try:
+            env_path.rename(temp_env)
             path = env.read_env(return_path=True)
+            assert path is None
         finally:
             # Restore .env file
             if temp_env.exists():
                 temp_env.rename(env_path)
-            assert path == ""
-
-        assert path == ""
 
 
 def always_fail(value):


### PR DESCRIPTION
The feature added by #364 introduced a behavior that `read_env()` would always recurse the tree directory even when it has already found a .env file. Sorry about that.

If you would have a .env file on your current working directory this file would be chosen instead another .env more deep on the tree where `read_env()` was called.

Bug fixed and I added tests to caught this behavior on future releases. 