### PR TITLE
Remove required argument from parser methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changes:
 
 - _Backwards-incompatible_: `recurse`, `verbose`, `override`,
   and `return_path` parameters to `Env.read_env` are now keyword-only.
+- _Backwards-incompatible_: The `required` argument to parser methods
+  is removed. Call a parser method without a default value to make it required.
 
 ## 14.1.0 (2025-01-10)
 

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -80,7 +80,6 @@ def _field2method(
             | typing.Iterable[typing.Callable[[typing.Any], typing.Any]]
             | None
         ) = None,
-        required: bool = False,
         # Additional kwargs are passed to Field constructor
         **kwargs,
     ) -> _T | None:
@@ -98,7 +97,6 @@ def _field2method(
         ):
             field = field_or_factory(
                 validate=validate,
-                required=required,
                 load_default=load_default,
                 **kwargs,
             )
@@ -107,7 +105,6 @@ def _field2method(
             field = typing.cast(FieldFactory, field_or_factory)(
                 subcast=parsed_subcast,
                 validate=validate,
-                required=required,
                 load_default=load_default,
             )
         parsed_key, value, proxied_key = self._get_from_environ(name, default=Ellipsis)

--- a/src/environs/types.py
+++ b/src/environs/types.py
@@ -34,13 +34,12 @@ ParserMethod: typing.TypeAlias = typing.Callable[..., typing.Any]
 
 
 class BaseMethodKwargs(typing.TypedDict, total=False):
-    # Subset of relevant marshmallow.Field kwargs shared by all parser methods
+    # Relevant marshmallow.Field kwargs shared by all parser methods
     validate: (
         typing.Callable[[typing.Any], typing.Any]
         | typing.Iterable[typing.Callable[[typing.Any], typing.Any]]
         | None
     )
-    required: bool
 
 
 class FieldMethod(typing.Generic[T]):


### PR DESCRIPTION
`required` is redundant with not passing a default value to parser methods.


it was never documented so arguably not a breaking change, but marking it as such anyway in the changelog in case anyone found it on accident.