### PR TITLE
Add delimiter for key-value for dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ export TTL=42
 export ENABLE_LOGIN=true
 export GITHUB_REPOS=webargs,konch,ped
 export GITHUB_REPO_PRIORITY="webargs=2,konch=3"
+export LOCATIONS="x:234 y:123"
 export COORDINATES=23.3,50.0
 export LOG_LEVEL=DEBUG
 ```
@@ -91,6 +92,11 @@ coords = env.list("COORDINATES", subcast=float)  # => [23.3, 50.0]
 gh_repos_priorities = env.dict(
     "GITHUB_REPO_PRIORITY", subcast_values=int
 )  # => {'webargs': 2, 'konch': 3}
+
+# parsing dicts with different delimiters
+locations = env.dict(
+    "LOCATIONS", subcast_values=int, delimiter=" ", key_value_delimiter=":"
+)  # => {'x': 234, 'y': 123}
 ```
 
 ## Supported types
@@ -103,7 +109,7 @@ The following are all type-casting methods of `Env`:
 - `env.float`
 - `env.decimal`
 - `env.list` (accepts optional `subcast` and `delimiter` keyword arguments)
-- `env.dict` (accepts optional `subcast_keys`, `subcast_values` and `delimiter` keyword arguments)
+- `env.dict` (accepts optional `subcast_keys`, `subcast_values`, `delimiter`, and `key_value_delimiter` keyword arguments)
 - `env.json`
 - `env.datetime`
 - `env.date`

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -228,6 +228,7 @@ def _preprocess_dict(
     subcast_keys: Subcast | None = None,
     subcast_values: Subcast | None = None,
     delimiter: str = ",",
+    key_value_delimiter: str = "=",
     **kwargs,
 ) -> typing.Mapping:
     if isinstance(value, Mapping):
@@ -247,7 +248,9 @@ def _preprocess_dict(
         subcast_keys_instance.deserialize(
             key.strip(),
         ): subcast_values_instance.deserialize(val.strip())
-        for key, val in (item.split("=", 1) for item in value.split(delimiter) if value)
+        for key, val in (
+            item.split(key_value_delimiter, 1) for item in value.split(delimiter) if value
+        )
     }
 
 
@@ -331,6 +334,7 @@ class Env:
             "subcast_key",
             "subcast_values",
             "delimiter",
+            "key_value_delimiter",
         ),
     )
     json: FieldMethod[_ListType | _DictType] = _field2method(

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -152,6 +152,10 @@ class TestCasting:
         set_env({"DICT": "key1=1 key2=2"})
         assert env.dict("DICT", delimiter=" ") == {"key1": "1", "key2": "2"}
 
+    def test_dict_with_colon_key_value_delimiter(self, set_env, env: environs.Env):
+        set_env({"DICT": "key1:1,key2:2"})
+        assert env.dict("DICT", key_value_delimiter=":") == {"key1": "1", "key2": "2"}
+
     def test_dict_with_subcast_values(self, set_env, env: environs.Env):
         set_env({"DICT": "key1=1,key2=2"})
         assert env.dict("DICT", subcast_values=int) == {"key1": 1, "key2": 2}


### PR DESCRIPTION
Adds delimiter to separate the key and value in parsing dicts, allowing for any type of dict to be parsed.
Example added to README as well.