### PR TITLE
Add an env reader that checks for secret files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 14.3.0 (unreleased)
+
+Features:
+
+- Add `environs.FileAwareEnv` for reading secret files ([#410](https://github.com/sloria/environs/pull/410)).
+  Thanks [holtgrewe](https://github.com/holtgrewe) for the suggestion.
+  Thanks [whyscream](https://github.com/whyscream) and [avilaton](https://github.com/avilaton) for the PRs.
+
 ## 14.2.0 (2025-05-22)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ It allows you to store configuration separate from your code, as per
 - [Deferred validation](#deferred-validation)
 - [URL schemes](#url-schemes)
 - [Serialization](#serialization)
+- [Reading Docker-style secret files](#reading-docker-style-secret-files)
 - [Defining custom parser behavior](#defining-custom-parser-behavior)
 - [Usage with Flask](#usage-with-flask)
 - [Usage with Django](#usage-with-django)
@@ -337,6 +338,36 @@ env.dump()
 # 'MYAPP_PORT': 3000,
 # 'SHIP_DATE': '1984-06-25',
 # 'TTL': 42}
+```
+
+## Reading Docker-style secret files
+
+Some values should not be stored in the environment. For this use case a commonly
+used technique is to store the value (f.i. a password) in a file, and set the path
+to that file in an environment variable. Use `FileAwareEnv` in place of `Env` and
+it will automatically check for environment variables with `_FILE` appended. If the
+file is found, its contents will be read and returned.
+
+```python
+from environs import FileAwareEnv
+
+# echo 'my secret password' > /run/secrets/password
+# export PASSWORD_FILE=/run/secrets/password
+
+env = FileAwareEnv()
+password = env.str("PASSWORD")  # => 'my secret  password'
+```
+
+It's also possible to set a different suffix for the variable names:
+
+```python
+from environs import FileAwareEnv
+
+# echo 'my secret password' > /run/secrets/password
+# export PASSWORD_SECRET=/run/secrets/password
+
+env = FileAwareEnv(file_suffix="_SECRET")
+password = env.str("PASSWORD")  #  => 'my secret password'
 ```
 
 ## Defining custom parser behavior

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ env.dump()
 ## Reading Docker-style secret files
 
 Some values should not be stored in the environment. For this use case a commonly
-used technique is to store the value (f.i. a password) in a file, and set the path
+used technique is to store the value (e.g., a password) in a file and set the path
 to that file in an environment variable. Use `FileAwareEnv` in place of `Env` and
 it will automatically check for environment variables with `_FILE` appended. If the
 file is found, its contents will be read and returned.

--- a/README.md
+++ b/README.md
@@ -344,8 +344,7 @@ env.dump()
 
 Some values should not be stored in the environment. For this use case a commonly
 used technique is to store the value (e.g., a password) in a file and set the path
-to that file in an environment variable. Use `FileAwareEnv` in place of `Env` and
-it will automatically check for environment variables with `_FILE` appended. If the
+to that file in an environment variable. Use `FileAwareEnv` in place of `Env` to automatically check for environment variables with the `_FILE` suffix. If the
 file is found, its contents will be read and returned.
 
 ```python

--- a/examples/fileaware_example.py
+++ b/examples/fileaware_example.py
@@ -1,0 +1,19 @@
+import os
+from tempfile import NamedTemporaryFile
+
+from environs import FileAwareEnv
+
+# Create a secret file
+with NamedTemporaryFile(delete=False) as secret_file:
+    secret_file.write(b"some secret value")
+    secret_file.close()
+    os.environ["MYSECRET_FILE"] = str(secret_file.name)
+
+env = FileAwareEnv()
+
+value = env.str("MYSECRET")
+assert value == "some secret value"
+print(value)
+
+# cleanup
+os.unlink(secret_file.name)

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -569,16 +569,14 @@ class Env:
     def _get_key(self, key: _StrType, *, omit_prefix: _BoolType = False) -> _StrType:
         return self._prefix + key if self._prefix and not omit_prefix else key
 
-    @staticmethod
-    def _get_value(env_key, default):
+    def _get_value(self, env_key, default):
         return os.environ.get(env_key, default)
 
 
 class FileAwareEnv(Env):
     """An environment variable reader that supports reading values from files."""
 
-    @staticmethod
-    def _get_value(env_key, default):
+    def _get_value(self, env_key, default):
         """Return the contents of the file referenced in key <env_key>_FILE, if present."""
         file_key = env_key + "_FILE"
         if file_path := os.environ.get(file_key, None):

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -569,14 +569,14 @@ class Env:
     def _get_key(self, key: _StrType, *, omit_prefix: _BoolType = False) -> _StrType:
         return self._prefix + key if self._prefix and not omit_prefix else key
 
-    def _get_value(self, env_key, default):
+    def _get_value(self, env_key: _StrType, default: typing.Any) -> typing.Any:
         return os.environ.get(env_key, default)
 
 
 class FileAwareEnv(Env):
     """An environment variable reader that supports reading values from files."""
 
-    def _get_value(self, env_key, default):
+    def _get_value(self, env_key: _StrType, default: typing.Any) -> typing.Any:
         """Return the contents of the file referenced in key <env_key>_FILE, if present."""
         file_key = env_key + "_FILE"
         if file_path := os.environ.get(file_key, None):

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -577,13 +577,13 @@ class FileAwareEnv(Env):
     """An environment variable reader that supports reading values from files."""
 
     def __init__(
-        self, 
-        *, 
-        file_suffix: _StrType = "_FILE", 
+        self,
+        *,
+        file_suffix: _StrType = "_FILE",
         eager: _BoolType = True,
         expand_vars: _BoolType = False,
         prefix: _StrType | None = None,
-    :
+    ):
         self.file_suffix = file_suffix
         super().__init__(eager=eager, expand_vars=expand_vars, prefix=prefix)
 
@@ -594,7 +594,9 @@ class FileAwareEnv(Env):
             try:
                 return Path(file_path).read_text()
             except (FileNotFoundError, IsADirectoryError, PermissionError) as err:
-                raise ValueError(f"The value of {file_key} must be a readable file path.") from err
+                raise ValueError(
+                    f"The value of {file_key} must be a readable file path."
+                ) from err
         return super()._get_value(env_key, default)
 
 

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -576,9 +576,13 @@ class Env:
 class FileAwareEnv(Env):
     """An environment variable reader that supports reading values from files."""
 
+    def __init__(self, *, file_suffix: _StrType = "_FILE", **kwargs):
+        self.file_suffix = file_suffix
+        super().__init__(**kwargs)
+
     def _get_value(self, env_key: _StrType, default: typing.Any) -> typing.Any:
         """Return the contents of the file referenced in key <env_key>_FILE, if present."""
-        file_key = env_key + "_FILE"
+        file_key = f"{env_key}{self.file_suffix}"
         if file_path := os.environ.get(file_key, None):
             try:
                 return Path(file_path).read_text()

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -594,7 +594,7 @@ class FileAwareEnv(Env):
             try:
                 return Path(file_path).read_text()
             except (FileNotFoundError, IsADirectoryError, PermissionError) as err:
-                raise ValueError("path should exist and be a readable file") from err
+                raise ValueError(f"The value of {file_key} must be a readable file path.") from err
         return super()._get_value(env_key, default)
 
 

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -582,7 +582,10 @@ class FileAwareEnv(Env):
         """Return the contents of the file referenced in key <env_key>_FILE, if present."""
         file_key = env_key + "_FILE"
         if file_path := os.environ.get(file_key, None):
-            return Path(file_path).read_text()
+            try:
+                return Path(file_path).read_text()
+            except (FileNotFoundError, IsADirectoryError, PermissionError) as err:
+                raise ValueError("path should exist and be a readable file") from err
         return super()._get_value(env_key, default)
 
 

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -576,9 +576,16 @@ class Env:
 class FileAwareEnv(Env):
     """An environment variable reader that supports reading values from files."""
 
-    def __init__(self, *, file_suffix: _StrType = "_FILE", **kwargs):
+    def __init__(
+        self, 
+        *, 
+        file_suffix: _StrType = "_FILE", 
+        eager: _BoolType = True,
+        expand_vars: _BoolType = False,
+        prefix: _StrType | None = None,
+    :
         self.file_suffix = file_suffix
-        super().__init__(**kwargs)
+        super().__init__(eager=eager, expand_vars=expand_vars, prefix=prefix)
 
     def _get_value(self, env_key: _StrType, default: typing.Any) -> typing.Any:
         """Return the contents of the file referenced in key <env_key>_FILE, if present."""

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -44,7 +44,7 @@ if typing.TYPE_CHECKING:
     except ImportError:
         pass
 
-__all__ = ["Env", "EnvError", "ValidationError", "env"]
+__all__ = ["Env", "EnvError", "FileAwareEnv", "ValidationError", "env"]
 
 _T = typing.TypeVar("_T")
 _StrType = str

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -1115,7 +1115,9 @@ class TestFileAwareEnv:
             }
         )
 
-        with pytest.raises(ValueError, match="path should exist and be a readable file"):
+        with pytest.raises(
+            ValueError, match="The value of KEY_FILE must be a readable file path."
+        ):
             fa_env.str("KEY")
 
     def test_read_from_file_path_is_not_a_file(self, fa_env, tmp_path, set_env):
@@ -1127,7 +1129,9 @@ class TestFileAwareEnv:
             }
         )
 
-        with pytest.raises(ValueError, match="path should exist and be a readable file"):
+        with pytest.raises(
+            ValueError, match="The value of KEY_FILE must be a readable file path."
+        ):
             fa_env.str("KEY")
 
     def test_read_from_file_path_is_unreadable(self, fa_env, tmp_path, set_env):
@@ -1140,7 +1144,9 @@ class TestFileAwareEnv:
             }
         )
 
-        with pytest.raises(ValueError, match="path should exist and be a readable file"):
+        with pytest.raises(
+            ValueError, match="The value of KEY_FILE must be a readable file path."
+        ):
             assert fa_env.str("KEY")
 
     def test_read_from_file_types(self, fa_env, set_env_file):

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -1170,3 +1170,14 @@ class TestFileAwareEnv:
         # use it as a string
         file_as_str = fa_env.str("KEY_FILE")
         assert str(file_as_path) == file_as_str
+
+    def test_expand_value_from_file(self, set_env, set_env_file):
+        fa_env = environs.FileAwareEnv(expand_vars=True)
+
+        set_env({"DATABASE_URL": "postgres://user:${PASSWORD}@host:5432/dbname"})
+        set_env_file("PASSWORD", "secret")
+
+        assert fa_env.str("DATABASE_URL") == "postgres://user:secret@host:5432/dbname"
+
+    def test_read_from_file_fall_back_to_default(self, fa_env, set_env_file):
+        assert fa_env.str("KEY", default="default value") == "default value"


### PR DESCRIPTION
Add support for reading Docker-style secret files out of the box.

This pretty much mimics the [`FileAwareEnv` feature in django-environ](https://django-environ.readthedocs.io/en/latest/tips.html#docker-style-file-based-variables). 

I also added support for changing the `_FILE` suffix, something that `django-environ` doesn't have.

Steps to complete:

- [x] Add actual feature
- [x] Add unittests for basic functionality (see https://github.com/sloria/environs/pull/295#issuecomment-1884989970)
- [x] Add example to `example/` folder
- [x] Document workings in README

Based on the work by @avilaton in https://github.com/sloria/environs/pull/295

Should resolve https://github.com/sloria/environs/issues/410