### PR TITLE
feat: default dj_db_url() to the DATABASE_URL env var name

### DIFF
--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -142,10 +142,14 @@ def _field2method(
     return method
 
 
-def _func2method(func: typing.Callable[..., _T], method_name: str) -> typing.Any:
+def _func2method(
+    func: typing.Callable[..., _T],
+    method_name: str,
+    default_name: str | None = None,
+) -> typing.Any:
     def method(
         self: Env,
-        name: str,
+        name: str | None = None,
         default: typing.Any = ...,
         **kwargs,
     ) -> _T | None:
@@ -153,6 +157,12 @@ def _func2method(func: typing.Callable[..., _T], method_name: str) -> typing.Any
             raise EnvSealedError(
                 "Env has already been sealed. New values cannot be parsed.",
             )
+        if name is None:
+            if default_name is None:
+                raise TypeError(
+                    f"{method_name}() missing required argument: 'name'",
+                )
+            name = default_name
         parsed_key, raw_value, proxied_key = self._get_from_environ(name, default)
         self._fields[parsed_key] = ma.fields.Raw()
         source_key = proxied_key or parsed_key
@@ -357,7 +367,7 @@ class Env:
     url: FieldMethod[ParseResult] = _field2method(fields.Url, "url")
 
     enum: EnumFieldMethod = _field2method(ma.fields.Enum, "enum")
-    dj_db_url = _func2method(_dj_db_url_parser, "dj_db_url")
+    dj_db_url = _func2method(_dj_db_url_parser, "dj_db_url", default_name="DATABASE_URL")
     dj_email_url = _func2method(_dj_email_url_parser, "dj_email_url")
     dj_cache_url = _func2method(_dj_cache_url_parser, "dj_cache_url")
 

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -916,6 +916,12 @@ class TestDjango:
         res = env.dj_db_url("DATABASE_URL")
         assert res == dj_database_url.parse(db_url)
 
+    def test_dj_db_url_defaults_to_database_url(self, env: environs.Env, set_env):
+        db_url = "postgresql://localhost:5432/mydb"
+        set_env({"DATABASE_URL": db_url})
+        res = env.dj_db_url()
+        assert res == dj_database_url.parse(db_url)
+
     def test_dj_db_url_passes_kwargs(self, env: environs.Env, set_env):
         db_url = "postgresql://localhost:5432/mydb"
         set_env({"DATABASE_URL": db_url})


### PR DESCRIPTION
Makes `env.dj_db_url()` default to the `DATABASE_URL` environment variable when no name is given, matching the underlying `dj-database-url` package. Passing an explicit name still works unchanged, and the same default-name mechanism is available to other `_func2method` parsers.

Closes #415