### PR TITLE
Restore prefix after prefixed errors

### DIFF
--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -462,8 +462,7 @@ class Env:
             yield self
         finally:
             # explicitly reset the stored prefix on completion and exceptions
-            self._prefix = None
-        self._prefix = old_prefix
+            self._prefix = old_prefix
 
     def seal(self) -> None:
         """Validate parsed values and prevent new values from being added.

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -903,6 +903,20 @@ class TestFailedNestedPrefix:
         except FauxTestError:
             dump_with_nested_prefixed(env, fail=False)
 
+    def test_failed_prefixed_restores_configured_prefix(self, set_env):
+        set_env({"APP_STR": "foo", "APP_NESTED_INT": "42"})
+        env = environs.Env(prefix="APP_")
+
+        def raise_inside_prefixed():
+            with env.prefixed("NESTED_"):
+                assert env.int("INT") == 42
+                raise FauxTestError
+
+        with pytest.raises(FauxTestError):
+            raise_inside_prefixed()
+
+        assert env.str("STR") == "foo"
+
 
 class TestDjango:
     def test_dj_db_url(self, env: environs.Env, set_env):


### PR DESCRIPTION
## What changed

`Env.prefixed()` now restores the previous prefix from its `finally` block.

## Why

When an exception is raised inside a nested `prefixed()` block on an `Env` that was constructed with `prefix=...`, the old prefix was not restored. The `finally` block set `_prefix` to `None`, and the later restoration line was skipped by the exception path.

## Validation

- `python -m pytest tests\test_environs.py::TestFailedNestedPrefix::test_failed_prefixed_restores_configured_prefix -q` failed before the fix
- `python -m pytest tests\test_environs.py::TestFailedNestedPrefix -q`
- `python -m ruff check src\environs\__init__.py tests\test_environs.py`
- `python -m ruff format --check src\environs\__init__.py tests\test_environs.py`
- `git diff --check`

I also ran `python -m pytest tests\test_environs.py -q`; it passed the changed tests and reported one unrelated Windows-local failure in `TestFileAwareEnv.test_read_from_file_path_is_unreadable`, where `chmod(0o000)` does not make the file unreadable for this user on Windows.