### PR TITLE
feat: distinguish missing environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 15.1.0 (unreleased)
+
+Features:
+
+- Add a specific exception, `EnvNotSetError`, for missing environment variables ([#480](https://github.com/sloria/environs/issues/480)).
+  Thanks [paduszyk](https://github.com/paduszyk) for the suggestion and [w3lld1](https://github.com/sloria/environs/pull/481) for the PR.
+
 ## 15.0.1 (2026-04-06)
 
 Bug fixes:

--- a/src/environs/__init__.py
+++ b/src/environs/__init__.py
@@ -17,6 +17,7 @@ from dotenv.main import _walk_to_root, dotenv_values
 from . import fields
 from .exceptions import (
     EnvError,
+    EnvNotSetError,
     EnvSealedError,
     EnvValidationError,
     ParserConflictError,
@@ -118,7 +119,7 @@ def _field2method(
                 self._values[parsed_key] = default
                 return default
             if self.eager:
-                raise EnvError(
+                raise EnvNotSetError(
                     f'Environment variable "{proxied_key or parsed_key}" not set',
                 )
             self._errors[parsed_key].append("Environment variable not set.")
@@ -158,7 +159,7 @@ def _func2method(func: typing.Callable[..., _T], method_name: str) -> typing.Any
         source_key = proxied_key or parsed_key
         if raw_value is Ellipsis:
             if self.eager:
-                raise EnvError(
+                raise EnvNotSetError(
                     f'Environment variable "{proxied_key or parsed_key}" not set',
                 )
             self._errors[parsed_key].append("Environment variable not set.")

--- a/src/environs/exceptions.py
+++ b/src/environs/exceptions.py
@@ -7,9 +7,11 @@ if TYPE_CHECKING:
 
 
 class EnvError(ValueError):
-    """Raised when an environment variable or
-    if a required environment variable is unset.
-    """
+    """Base exception for errors raised while parsing environment variables."""
+
+
+class EnvNotSetError(EnvError):
+    """Raised when a required environment variable is unset."""
 
 
 class EnvValidationError(EnvError):

--- a/tests/test_environs.py
+++ b/tests/test_environs.py
@@ -71,6 +71,12 @@ class TestCasting:
         assert env("NOT_SET", "mydefault") == "mydefault"
         assert env("NOT_SET", None) is None
 
+    def test_missing_variable_raises_not_set_error(self, env: environs.Env):
+        with pytest.raises(environs.EnvNotSetError) as excinfo:
+            env.str("NOT_SET")
+
+        assert isinstance(excinfo.value, environs.EnvError)
+
     def test_basic(self, set_env, env: environs.Env):
         set_env({"STR": "foo"})
         assert env.str("STR") == "foo"
@@ -672,7 +678,7 @@ class TestCustomTypes:
 
         assert env.https_url("URL") == "https://test.test/"
 
-        with pytest.raises(environs.EnvError) as excinfo:
+        with pytest.raises(environs.EnvNotSetError) as excinfo:
             env.https_url("NOT_SET")
         assert excinfo.value.args[0] == 'Environment variable "NOT_SET" not set'
 


### PR DESCRIPTION
## Summary

- add `EnvNotSetError` as a specific `EnvError` subtype for required variables that are absent
- raise it consistently from built-in field parsers and custom function parsers
- keep existing `except EnvError` handling backward-compatible

## Verification

- `uv run pytest -q` (134 passed)
- `uv run tox -e lint`
- `uv build`
- `uvx twine check --strict dist/*`
- installed the built wheel into an isolated target and verified `EnvNotSetError` is publicly importable and remains an `EnvError`

Fixes #480
